### PR TITLE
fix warning when no row_grp_structures supplied; respect group ordering

### DIFF
--- a/R/apply_tfrmt.R
+++ b/R/apply_tfrmt.R
@@ -8,6 +8,7 @@
 #'
 #' @noRd
 apply_tfrmt <- function(.data, tfrmt, mock = FALSE){
+
   validate_cols_match(.data, tfrmt, mock)
 
   if(!is_tfrmt(tfrmt)){
@@ -41,10 +42,10 @@ tbl_dat <- apply_table_frmt_plan(
  tbl_dat_wide <- tbl_dat_span_cols %>%
    pivot_wider_tfrmt(tfrmt, mock) %>%
     tentative_process(arrange_enquo, tfrmt$sorting_cols, fail_desc= "Unable to arrange dataset") %>%
-    tentative_process(apply_row_grp_struct, tfrmt$row_grp_plan, tfrmt$group, tfrmt$label) %>%
+    tentative_process(apply_row_grp_struct, tfrmt$row_grp_plan$struct_ls, tfrmt$group, tfrmt$label) %>%
     #Select before grouping to not have to deal with if it indents or not
     tentative_process(select_col_plan, tfrmt, fail_desc = "Unable to subset dataset columns") %>%
-    tentative_process(apply_row_grp_lbl, tfrmt$row_grp_plan, tfrmt$group, tfrmt$label)
+    tentative_process(apply_row_grp_lbl, tfrmt$row_grp_plan$label_loc, tfrmt$group, tfrmt$label)
 
 
   tbl_dat_wide
@@ -61,11 +62,12 @@ tbl_dat <- apply_table_frmt_plan(
 #'
 #' @return processed data
 #' @importFrom purrr map_lgl
+#' @importFrom rlang is_empty
 #' @noRd
 tentative_process <- function(.data, fx, ..., fail_desc = NULL){
   args <- list(...)
 
-  if(any(map_lgl(args, is.null))){
+  if(any(map_lgl(args, is_empty))){
     out <- .data
   } else{
     out <- .data %>%

--- a/tests/testthat/test-apply_row_grp_plan.R
+++ b/tests/testthat/test-apply_row_grp_plan.R
@@ -14,7 +14,7 @@ test_that("insert post space - single grouping variable",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1), sym("label")),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1), sym("label")),
     tribble(
       ~grp1,~label, ~trtA,      ~trtB,      ~trtC,
       "A",  "1",  "xx (xx%)", "xx (xx%)", "xx (xx%)",
@@ -33,7 +33,7 @@ test_that("insert post space - single grouping variable",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1), sym("label")),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1), sym("label")),
     tribble(
       ~grp1, ~label, ~trtA,      ~trtB,       ~trtC,
       "A", "1", "xx (xx%)", "xx (xx%)", "xx (xx%)",
@@ -65,7 +65,7 @@ test_that("insert post space - two grouping variables",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1, grp2), label = sym("label")),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1, grp2), label = sym("label")),
     tribble(
       ~grp1, ~grp2, ~label,   ~trtA,       ~trtB,     ~trtC,
       "A",  "a",   "1", "xx (xx%)" ,"xx (xx%)", "xx (xx%)",
@@ -104,7 +104,7 @@ test_that("insert mix - single grouping variable",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1)),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1)),
     tribble(
       ~grp1, ~trtA,      ~trtB,      ~trtC,
       "A",  "xx (xx%)", "xx (xx%)",  "xx (xx%)",
@@ -137,7 +137,7 @@ test_that("insert post space after specific value",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1, grp2), label = sym("label")),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1, grp2), label = sym("label")),
     tribble(
       ~grp1,  ~grp2, ~label,   ~trtA,       ~trtB,     ~trtC,
       "A",     "a", "1",   "xx (xx%)", "xx (xx%)", "xx (xx%)",
@@ -173,7 +173,7 @@ test_that("overlapping row_grp_structures - prefers latest",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1, grp2), label = sym("label")),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1, grp2), label = sym("label")),
     tribble(
       ~grp1,  ~grp2, ~label,   ~trtA,       ~trtB,     ~trtC,
       "A",     "a", "1",   "xx (xx%)", "xx (xx%)", "xx (xx%)",
@@ -208,7 +208,7 @@ test_that("no post space added if NULL",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1)),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1)),
     tribble(
       ~grp1, ~trtA,      ~trtB,      ~trtC,
       "A",  "xx (xx%)", "xx (xx%)", "xx (xx%)",
@@ -235,7 +235,7 @@ test_that("post space is truncated to data width",{
   )
 
   expect_equal(
-    apply_row_grp_struct(df, sample_grp_plan, vars(grp1)),
+    apply_row_grp_struct(df, sample_grp_plan$struct_ls, vars(grp1)),
     tribble(
       ~grp1, ~trtA,      ~trtB,      ~trtC,
       "A",  "xx (xx%)", "xx (xx%)",  "xx (xx%)",
@@ -366,7 +366,7 @@ test_that("> 2 groups with and without spanner_label", {
   )
 
   expect_equal(
-    apply_row_grp_lbl(mock_multi_grp, plan_no_span, vars(grp1, grp2, grp3), sym("my_label")),
+    apply_row_grp_lbl(mock_multi_grp, plan_no_span$label_loc, vars(grp1, grp2, grp3), sym("my_label")),
     tribble(
       ~my_label        , ~trtA     , ~trtB     , ~trtC   ,
       "grp1_1"          ,""          ,""         ,""        ,
@@ -390,7 +390,7 @@ test_that("> 2 groups with and without spanner_label", {
   plan_with_span <- row_grp_plan(label_loc= element_row_grp_loc(location = "spanning"))
 
   expect_equal(
-    apply_row_grp_lbl(mock_multi_grp, plan_with_span, vars(grp1, grp2, grp3), sym("my_label")),
+    apply_row_grp_lbl(mock_multi_grp, plan_with_span$label_loc, vars(grp1, grp2, grp3), sym("my_label")),
     tribble(
      ~grp1,   ~my_label        , ~trtA     , ~trtB     , ~trtC   ,
      "grp1_1", "grp2_1"         ,""         ,""         ,"",
@@ -434,7 +434,7 @@ test_that("Summary rows are not indented", {
   )
 
   expect_equal(
-    apply_row_grp_lbl(mock_multi_grp, plan_no_span, vars(grp1, grp2), sym("my_label")),
+    apply_row_grp_lbl(mock_multi_grp, plan_no_span$label_loc, vars(grp1, grp2), sym("my_label")),
     tribble(
       ~my_label ,        ~trtA       , ~trtB       , ~trtC,
       "cat_1"            ,"xx (xx%)" ,"xx (xx%)" ,"xx (xx%)",
@@ -452,7 +452,7 @@ test_that("Summary rows are not indented", {
   plan_with_span <- row_grp_plan(label_loc= element_row_grp_loc(location = "spanning"))
 
   expect_equal(
-    apply_row_grp_lbl(mock_multi_grp, plan_with_span, vars(grp1, grp2), sym("my_label")),
+    apply_row_grp_lbl(mock_multi_grp, plan_with_span$label_loc, vars(grp1, grp2), sym("my_label")),
     tribble(
       ~grp1,   ~my_label ,        ~trtA       , ~trtB       , ~trtC,
        "cat_1", "cat_1"          ,"xx (xx%)" ,"xx (xx%)" ,"xx (xx%)",
@@ -467,4 +467,113 @@ test_that("Summary rows are not indented", {
     ) %>% group_by(grp1)
   )
 
+})
+
+test_that("row order is retained for all selections",{
+
+  dat <- tribble(
+    ~grp1, ~grp2, ~lbl, ~prm, ~column, ~val, ~ord,
+    "d",   "c",   "n", "n",   1,   1,  1,
+    "a",   "b",   "m", "n",   1,   2,  2,
+    "q",   "v",   "s", "n",   1,   3,  3,
+    "b",   "p",   "e", "n",   1,   4,  4
+  )
+
+  tfrmt_temp <- tfrmt(
+    group = c(grp1, grp2),
+    label = lbl,
+    column = column,
+    values = val,
+    param = prm,
+    sorting_cols = ord,
+    col_plan = col_plan(-ord),
+    body_plan = body_plan(
+      frmt_structure(group_val = ".default", label_val = ".default", frmt("x"))
+    )
+  )
+
+  gt_indented <-  tfrmt_temp %>%
+    tfrmt(
+      row_grp_plan = row_grp_plan(label_loc = element_row_grp_loc(location = "indented"))
+    ) %>%
+    print_to_gt(dat)
+
+
+  gt_indented_dat <- gt_indented$`_data`
+  gt_indented_man <- tribble(
+    ~lbl,       ~`1`,
+    "d"       ,"" ,
+    "  c"    ,"" ,
+    "    n"  ,"1",
+    "a"      ,"" ,
+    "  b"    ,"" ,
+    "    m"  ,"2",
+    "q"      ,"" ,
+    "  v"    ,"" ,
+    "    s"  ,"3",
+    "b"      ,"" ,
+    "  p"    ,"" ,
+    "    e"  ,"4" )
+  expect_equal(gt_indented_dat, gt_indented_man)
+
+
+  gt_spanning <-  tfrmt_temp %>%
+    tfrmt(
+      row_grp_plan = row_grp_plan(label_loc = element_row_grp_loc(location = "spanning"))
+    ) %>%
+    print_to_gt(dat)
+
+  gt_spanning_dat <- gt_spanning$`_data`
+  gt_spanning_man <- tribble(
+    ~ grp1,  ~lbl,       ~`1`,
+      "d",     "c"   , "" ,
+      "d",     "  n" , "1",
+      "a",     "b"   , "" ,
+      "a",     "  m" , "2",
+      "q",     "v"   , "" ,
+      "q",     "  s" , "3",
+      "b",     "p"   , "" ,
+      "b",     "  e" , "4")
+  expect_equal(gt_spanning_dat, gt_spanning_man)
+
+  gt_column <-  tfrmt_temp %>%
+    tfrmt(
+      row_grp_plan = row_grp_plan(label_loc = element_row_grp_loc(location = "column"))
+    ) %>%
+    print_to_gt(dat)
+
+  gt_column_dat <- gt_column$`_data`
+  expect_equal(gt_column_dat, gt_spanning_man)
+
+  # original order also respected if no order variable supplied
+  tfrmt(
+    group = c(grp1, grp2),
+    label = lbl,
+    column = column,
+    values = val,
+    param = prm,
+    body_plan = body_plan(
+      frmt_structure(group_val = ".default", label_val = ".default", frmt("x"))
+    ),
+    row_grp_plan = row_grp_plan(label_loc = element_row_grp_loc(location = "indented"))
+    ) %>%
+    print_to_gt(dat %>% select(-ord))
+
+
+  gt_indented_dat <- gt_indented$`_data`
+  gt_indented_man <- tribble(
+    ~lbl,       ~`1`,
+    "d"       ,"" ,
+    "  c"    ,"" ,
+    "    n"  ,"1",
+    "a"      ,"" ,
+    "  b"    ,"" ,
+    "    m"  ,"2",
+    "q"      ,"" ,
+    "  v"    ,"" ,
+    "    s"  ,"3",
+    "b"      ,"" ,
+    "  p"    ,"" ,
+    "    e"  ,"4" )
+  expect_equal(gt_indented_dat, gt_indented_man)
 })


### PR DESCRIPTION
resolves #146 

- Respect row group ordering in all cases (needed to move an existing bit of code up earlier in combine_grp_cols)
- pass the contents of row_grp_plan (struct_ls and label_loc) to the 2 functions rather than the whole object, allowing the tentative_process to check correctly
- change tentative_process to check for empty objects (rlang::is_empty) to cover empty lists in addition to NULL objects