### PR TITLE
Fixed section title "Creating a Standard tfrmt". Fixed very minor typos.

### DIFF
--- a/vignettes/body_plan.Rmd
+++ b/vignettes/body_plan.Rmd
@@ -60,7 +60,7 @@ This will cause the values 0.0347, 1.00, and 0.000001 to appear as "0.035", ">0.
 
 There are a variety of ways for the user to specify formatting locations: group variable values and/or label values, or by param value. Let's take a look at the various methods below, ranging from least specific to most specific. 
 
-An important details is that passing a value of ".default" to group or label means that the format will be applied to ALL values within the group(s) or label variables. 
+An important detail is that passing a value of ".default" to group or label means that the format will be applied to ALL values within the group(s) or label variables. 
 
 ## Table-wide
 

--- a/vignettes/examples.Rmd
+++ b/vignettes/examples.Rmd
@@ -95,11 +95,11 @@ tfrmt(
   )
 ```
 
-While this make a table it isn't a very nice table and definitely doesn't match the mock. So lets start with formatting all the numbers. To do this we are going to build a `body_plan` to add to our `tfrmt`.  This will be a fairly quick explanation of `body_plan`s but if you like more information see `vignettes("Body Plan")` 
+While this makes a table, it isn't a very nice table and definitely doesn't match the mock. So let's start with formatting all the numbers. To do this we are going to build a `body_plan` to add to our `tfrmt`.  This will be a fairly quick explanation of `body_plan`s but if you would like more information see `vignettes("Body Plan")` 
 
 Body plans are made up of a series of `frmt_stucture`s where each `frmt_stucture` represents the formatting of a cell within the table. The order of the `frmt_structure`s matter; they are always applied latest to oldest. This means the first `frmt_stucture` in the `body_plan` should be the most generic. You can use the groups, labels and parameters to specify which formatting applies to which values.  
 
-To start, we are going to use all the rows that are "n (%)" as the default. This way we don't need to list out every row that is an "n (%)" row. These rows are made up of two different values, so we will need to use `frmt_combine`. Next, we can format the continuous variables, which is just a straightforward one value per row so we can just use the label to filter and `frmt` to define the look. Finally, we want to format the p-values. This is a bit more complicated, since the p-value sits in the same row as other parameters; therefore the group and label value are not specific enough and we need something more granular. As such, we will need to specify the parameter in the `frmt_structure` like so `frmt_structure(group_val = ".default", label_val = ".default", p = frmt("x.xx")`. Further, we also need to make sure it never displays a rounded p-value of 0 or 1. So we can use `frmt_when` to specify the formatting based on the value. 
+To start, we are going to use all the rows that are "n (%)" as the default. This way we don't need to list out every row that is an "n (%)" row. These rows are made up of two different values, so we will need to use `frmt_combine`. Next, we can format the continuous variables, which is just a straightforward one value per row so we can just use the label to filter and `frmt` to define the look. Finally, we want to format the p-values. This is a bit more complicated, since the p-value sits in the same row as other parameters; therefore the group and label value are not specific enough and we need something more granular. As such, we will need to specify the parameter in the `frmt_structure` like so: `frmt_structure(group_val = ".default", label_val = ".default", p = frmt("x.xx")`. Further, we also need to make sure it never displays a rounded p-value of 0 or 1. So we can use `frmt_when` to specify the formatting based on the value. 
 ```{r}
 tfrmt(
   # specify columns in the data
@@ -126,7 +126,7 @@ tfrmt(
     container.width = 900
   )
 ```
-Now the numbers looks all correct, we can drop the order columns and the `grp` column (note that while we do not want to display the `grp` column, it plays a role behind the scenes, which will be addressed in the next step). To do this we use a `col_plan` which uses `tidy-select` nomenclature to drop/move columns. 
+Now that all the numbers look correct, we can drop the order columns and the `grp` column (note that while we do not want to display the `grp` column, it plays a role behind the scenes, which will be addressed in the next step). To do this we use a `col_plan` which uses `tidy-select` nomenclature to drop/move columns. 
 
 ```{r}
 tfrmt(
@@ -717,7 +717,7 @@ tfrmt(
 
 ```
 
-Notice that our row labels are not quite right. First, we have a bit of a hierarchy with the `label` values nested under the `group` values, and it would be nice to add some indentation to make the nesting more obvious. Also, some cases, the `group` values also contain summary data, which means the ARD contains a matching `group` and `label` value. For summary rows, we want to suppress the printing of the extra group-level header, and display the summary data in-line. The `row_grp_plan` can help us with both via the `row_grp_loc` argument:
+Notice that our row labels are not quite right. First, we have a bit of a hierarchy with the `label` values nested under the `group` values, and it would be nice to add some indentation to make the nesting more obvious. Also, in some cases, the `group` values also contain summary data, which means the ARD contains a matching `group` and `label` value. For summary rows, we want to suppress the printing of the extra group-level header, and display the summary data in-line. The `row_grp_plan` can help us with both via the `row_grp_loc` argument:
 
 ```{r}
 tfrmt(

--- a/vignettes/row_grp_plan.Rmd
+++ b/vignettes/row_grp_plan.Rmd
@@ -21,7 +21,7 @@ library(dplyr)
 library(gt)
 ```
 
-Performing many calculations within a group is easier than ever due to tools in the tidyverse. tfrmt's expectation of a standard, long data format is not only in alignment with tidy data principles and workflows, but it allows for the user to easy specify group-wise aesthetic formatting. tfrmt also allows the user to display row labels in a variety of ways. 
+Performing many calculations within a group is easier than ever due to tools in the tidyverse. tfrmt's expectation of a standard, long data format is not only in alignment with tidy data principles and workflows, but it allows for the user to easily specify group-wise aesthetic formatting. tfrmt also allows the user to display row labels in a variety of ways. 
 
 # Row group structure
 

--- a/vignettes/templates.Rmd
+++ b/vignettes/templates.Rmd
@@ -21,12 +21,12 @@ library(gt)
 library(tidyr)
 ```
 
-A core design element of `tfrmt` is to offer the ability to layer tfrmts together. This ability provides an opportunity for organizations to build template table formats that can be shared, improved, and reused across multiple projects. Through layering the users can customize the templates to create a specific table. 
+A core design element of `tfrmt` is to offer the ability to layer tfrmts together. This ability provides an opportunity for organizations to build template table formats that can be shared, improved, and reused across multiple projects. Through layering, the users can customize the templates to create a specific table. 
 
-A template is a function that given a set of inputs (or none) create a standard `tfrmt`. We will go through their applications below.  
+A template is a function that, given a set of inputs (or none), creates a standard `tfrmt`. We will go through their applications below.  
 We will create an Adverse Events table template in this vignette to demonstrate the ideas behind developing a template tfrmt.
-## Creating A Standard tfrmt
 
+## Creating a Standard tfrmt
 
 The first step to creating an Adverse Events table template is to determine the constants in the format. This requires there to be some standards that can be expected that allows the construction of the basic `tfrmt`:
 
@@ -95,7 +95,7 @@ ae_tfrmt_template <- tfrmt(
 
 ```
 
-## Functionalizing The Template
+## Functionalizing the Template
 
 Now that we have our tfrmt, we can wrap it into a function to form a template. This allows us to have as many layers as we'd like. For example, we can have an organization-level template to be used across all tables, a domain-level template to be used across all tables in a given domain, and a project-level template to be used for study-specific tables. 
 
@@ -342,10 +342,10 @@ tfrmt(
 
 Here we list some of the ideas about best practices when it comes to defining tfrmt templates for use across organization. This comes from experience writing and using `tfrmt` and has the potential to change. 
 
-A template tfrmt is intended to provide an interface for creating complex tfrmt's more easily. When creating the function, it is helpful to differentiate the aspects of the display that will remain constant from those are likely to change across tables or studies. These changes can be captured as arguments in the function. These functions should serve to provide a way to interact with and create tfrmt's for standard tables in such a way that customization for a specific table's `tfrmt` is simplified.
+A template tfrmt is intended to provide an interface for creating complex tfrmt's more easily. When creating the function, it is helpful to differentiate the aspects of the display that will remain constant from those which are likely to change across tables or studies. These changes can be captured as arguments in the function. These functions should serve to provide a way to interact with and create tfrmt's for standard tables in such a way that customization for a specific table's `tfrmt` is simplified.
 
 However, as with normal function development, this should be balanced with limiting the number of arguments necessary to pass and get a functional tfrmt. For example, `tfrmt_sigdig` accepts a minimal set of arguments, including a data.frame or tibble, to define a complex body_plan. Simplifying the way users may enter this complex set of instructions without having to manually type it is part of its strength.
 
-In addition to minimizing the arguments to a tfrmt template, it is generally simpler to define and enforce standards around things people can see in a table. For example, the grouping, labels, and value formats are easy to see and understand. Standardizing around meta information that impacts a table but may not as easily be seen, such as value context (params) is more difficult.
+In addition to minimizing the arguments to a tfrmt template, it is generally simpler to define and enforce standards around things people can see in a table. For example, the grouping, labels, and value formats are easy to see and understand. Standardizing around meta information that impacts a table but may not as easily be seen, such as value context (params), is more difficult.
 
 


### PR DESCRIPTION
Minor typo fixes in 4 vignettes. 

Section title of "Creating a Standard tfrmt" fixed in "Creating Template tfrmts" vignette (Issue #165).