### PR TITLE
Frmt combine check

### DIFF
--- a/R/apply_table_frmt_plan.R
+++ b/R/apply_table_frmt_plan.R
@@ -121,9 +121,14 @@ fmt_test_data <- function(cur_fmt, .data, label, group, param){
       distinct() %>%
       group_by(!!!group, !!label) %>%
       mutate(test = sum(!!parse_expr(parm_expr))) %>%
-      filter(test == length(cur_fmt$frmt_to_apply[[1]]$fmt_ls))
+      filter(test == length(cur_fmt$frmt_to_apply[[1]]$fmt_ls)) %>%
+      ungroup()
+    join_by <- c(group, label, param) %>%
+      map_chr(as_label) %>%
+      keep(~. != "<empty>")
+
     out <- complet_combo_grps %>%
-      left_join(out, by = c(group, label, param) %>% map_chr(as_label))
+      left_join(out, by = join_by)
   }
   out %>%
     pull(.data$TEMP_row)

--- a/tests/testthat/test-utils_tfrmt.R
+++ b/tests/testthat/test-utils_tfrmt.R
@@ -264,3 +264,47 @@ test_that("Test body_plan missing", {
                  pivot_wider(names_from = column, values_from = val))
 })
 
+
+test_that("incomplete body_plan where params share label",{
+
+  dd <- tibble::tribble(
+    ~rowlbl1, ~grp, ~rowlbl2, ~column, ~param, ~value,
+    "topgrp", "lowergrp1", "n pct", "A",  "n",   1,
+    "topgrp", "lowergrp1", "n pct", "A",  "pct",   50,
+    "topgrp", "lowergrp1", "mean", "A",  "mean",   2,
+    "topgrp", "lowergrp2", "n pct", "A",  "n",   2,
+    "topgrp", "lowergrp2", "n pct", "A",  "pct",   40,
+    "topgrp", "lowergrp2", "mean", "A",  "mean",   5
+  )
+
+  tfrmt_spec <- tfrmt(
+    group = c(rowlbl1,grp),
+    label = rowlbl2,
+    column = column,
+    param = param,
+    values = value,
+    body_plan = body_plan(
+      frmt_structure(group_val = ".default", label_val = "mean", frmt("xx.x"))
+    ),
+    row_grp_plan = row_grp_plan(
+      label_loc = element_row_grp_loc(location = "column")
+    )
+  )
+
+  expect_message(
+    auto_tfrmt <- apply_tfrmt(dd, tfrmt_spec),
+    "The following rows of the given dataset have no format applied to them 1, 2, 4, 5"
+  )
+
+  man_tfrmt <- tibble::tribble(
+    ~rowlbl1,  ~rowlbl2,    ~ A   ,
+      "topgrp", "lowergrp1", "",
+      "topgrp", "  mean"   , " 2.0",
+      "topgrp", "  n pct"   ,c("1","50"),
+      "topgrp", "lowergrp2", "",
+      "topgrp", "  mean"   , " 5.0",
+      "topgrp", "  n pct"  , c("2","40")
+  ) %>% group_by(rowlbl1)
+
+ expect_equal(auto_tfrmt, man_tfrmt)
+  })


### PR DESCRIPTION
I have added in the check for frmt_combine. So it only applies frmt_combine when all of the parameters are there. 

But, if you have the parameters for some of the columns but not all of them then you still run into the same NA issue. From the user perspective I feel like we need to resolve this either by adding a warning when this happens and leaving the NA's or allow people to use the missing arguments to fill in the missings. We could just use `replace_na` cause if they have a missing supplied then we are replacing all the other missings as well... don't know through maybe more thinking 