### PR TITLE
Fix for dev dplyr

### DIFF
--- a/R/apply_footnote_meta.R
+++ b/R/apply_footnote_meta.R
@@ -119,7 +119,7 @@ get_col_loc <- function(footnote_structure, .data, col_plan_vars, columns){
       if(last(col_str) == span_lvl){
         col_loc <- unite_df_to_data_names(col_loc_df, preselected_cols = c(), column_names = col_str)
         if(!is.null(names(col_loc))){
-          col_loc <- if_else(names(col_loc) != "", names(col_loc), col_loc)
+          col_loc <- if_else(names(col_loc) != "", names(col_loc), unname(col_loc))
         }
         out <- list(col = col_loc, spanning = FALSE)
       } else {

--- a/R/apply_tfrmt.R
+++ b/R/apply_tfrmt.R
@@ -309,6 +309,7 @@ pivot_wider_tfrmt <- function(data, tfrmt, mock){
     map_chr(as_name)
   tbl_dat_wide <- data %>%
     select(-!!tfrmt$param) %>%
+    mutate(across(all_of(column_cols), as.character)) %>%
     mutate(across(all_of(column_cols), na_if, "")) %>%
     quietly(pivot_wider)(
       names_from = c(starts_with(.tlang_struct_col_prefix), !!!tfrmt$column),

--- a/R/apply_tfrmt.R
+++ b/R/apply_tfrmt.R
@@ -319,7 +319,7 @@ pivot_wider_tfrmt <- function(data, tfrmt, mock){
       )
 
   if (mock == TRUE && length(tbl_dat_wide$warnings)>0 &&
-      str_detect(tbl_dat_wide$warnings, paste0("Values from `", as_label(tfrmt$value), "` are not uniquely identified"))){
+      any(str_detect(tbl_dat_wide$warnings, paste0("Values from `", as_label(tfrmt$value), "` are not uniquely identified")))){
     message("Mock data contains more than 1 param per unique label value. Param values will appear in separate rows.")
     tbl_dat_wide <- tbl_dat_wide$result %>%
       unnest(cols = everything()) %>%

--- a/R/frmt_plans.R
+++ b/R/frmt_plans.R
@@ -181,6 +181,7 @@ frmt_combine <- function(expression, ..., missing = NULL){
 
   n_vars <- str_count(expression, everything_but_curly)
   vars_to_fmt <- str_extract_all(expression, everything_but_curly, simplify = TRUE)
+  vars_to_fmt <- as.vector(vars_to_fmt)
   frmt_ls <- list(...)
 
   if(n_vars != length(frmt_ls) & length(frmt_ls) > 1){

--- a/tests/testthat/_snaps/make_mock_data.md
+++ b/tests/testthat/_snaps/make_mock_data.md
@@ -1,0 +1,7 @@
+# Check mock when value is missing
+
+    Code
+      out <- print_mock_gt(plan, data)
+    Message <simpleMessage>
+      Message: `tfrmt` will need `value` value to `print_to_gt` when data is avaliable
+

--- a/tests/testthat/test-make_mock_data.R
+++ b/tests/testthat/test-make_mock_data.R
@@ -194,8 +194,9 @@ test_that("Check mock when value is missing", {
   )
 
   #Make mock
-  quietly(print_mock_gt)(plan, data)$warnings %>%
-    expect_equal(character())
+  expect_snapshot(
+    out <- print_mock_gt(plan, data)
+  )
 })
 
 

--- a/tests/testthat/test-make_mock_data.R
+++ b/tests/testthat/test-make_mock_data.R
@@ -465,7 +465,7 @@ test_that("Mock data can be made and printed without label",{
   )
 
   #Make mock
-  expect_silent(
+  expect_no_message(
     print_mock_gt(plan, .data = dat)
   )
 

--- a/tests/testthat/test-make_mock_data.R
+++ b/tests/testthat/test-make_mock_data.R
@@ -539,10 +539,11 @@ test_that("Using col_plan to get column names", {
     )
   ) %>%
     make_mock_data() %>%
+    select(test1, test2) %>%
     distinct(test1, test2)
 
-  man_col_df <- tibble(test2 = c("col4","col3", "col5", "col1", "col2", "col7","col8"),
-                       test1 = c(rep(NA, 3), rep(c("span 1", "span 2"), each = 2)))
+  man_col_df <- tibble(test1 = c(rep(NA, 3), rep(c("span 1", "span 2"), each = 2)),
+                       test2 = c("col4","col3", "col5", "col1", "col2", "col7","col8"))
   expect_equal(auto_col_df, man_col_df)
 
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `if_else()` now propagates names so we need to unname where they aren't expected
- `na_if()` now coerces `y` to the type of `x` so we now need to convert `x` to character early in a place
- You had a place where `str_detect()` could return >1 values inside an `if()` so I wrapped that in `any()`
- `case_when()` and `if_else()` now retain the type of matrices rather than coercing them to vectors, so they need to be coerced to vector early
- `distinct()` now retains the ordering supplied by the user, so I've reordered with a `select()` early on to ensure this is compatible with both dev and CRAN dplyr
- There are a few places where I switched to `expect_no_message()` or `expect_snapshot()` due to new warnings that appear in the join functions. The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!