### PR TITLE
Just Suppressed the warning messages for now

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,7 +12,7 @@ reference:
   - apply_frmt
   - big_n_structure
   - body_plan
-  - col_plan, span_structure
+  - c(col_plan, span_structure)
   - col_style_plan
   - col_style_structure
   - data_ae
@@ -24,9 +24,9 @@ reference:
   - element_row_grp_loc
   - footnote_plan
   - footnote_structure
-  - frmt, frmt_combine, frmt_when
+  - c(frmt, frmt_combine, frmt_when)
   - frmt_structure
-  - is_frmt, is_frmt_combine, is_frmt_when, is_frmt_structure, is_row_grp_structure
+  - c(is_frmt, is_frmt_combine, is_frmt_when, is_frmt_structure, is_row_grp_structure)
   - json_to_tfrmt
   - layer_tfrmt
   - param_set

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,42 @@ template:
     image:
       src: man/figures/tfrmt.png
       alt: "tfrmt Hex Sticker"
+   
+reference:
+- title: All Functions
+  contents:
+  - apply_frmt
+  - big_n_structure
+  - body_plan
+  - col_plan, span_structure
+  - col_style_plan
+  - col_style_structure
+  - data_ae
+  - data_demog
+  - data_efficacy
+  - data_labs
+  - display_row_frmts
+  - element_block
+  - element_row_grp_loc
+  - footnote_plan
+  - footnote_structure
+  - frmt, frmt_combine, frmt_when
+  - frmt_structure
+  - is_frmt, is_frmt_combine, is_frmt_when, is_frmt_structure, is_row_grp_structure
+  - json_to_tfrmt
+  - layer_tfrmt
+  - param_set
+  - print_mock_gt
+  - print_to_ggplot
+  - print_to_gt
+  - row_grp_plan
+  - row_grp_structure
+  - tfrmt
+  - tfrmt_n_pct
+  - tfrmt_sigdig
+  - tfrmt_to_json
+  - update_group
+
 articles:
 - title: Table Components
   navbar: Table Components

--- a/vignettes/col_style_plan.Rmd
+++ b/vignettes/col_style_plan.Rmd
@@ -47,7 +47,10 @@ When the `col_style_plan()` is applied to the data, the most recent alignment an
 Let's take a look at how alignment can be applied to the example below, which contains a variety of different parameters which are formatted differently.
 
 <details>
-  <summary>Expand for the code used to produce the example data</summary>
+
+  <summary>
+  Expand for the code used to produce the example data.
+  </summary>
 ```{r}
 dat <- tribble(
   ~label     , ~param, ~column    , ~ value,   ~ord, 

--- a/vignettes/print_to_ggplot.Rmd
+++ b/vignettes/print_to_ggplot.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  warnings = FALSE
 )
 ```
 


### PR DESCRIPTION
You may not want to merge this change as I'm not yet convinced that I have gotten to the bottom of the warning messages in the 'Print to ggplot' vignette. But in case it serves as a temporary solution, I have just simply suppressed the warning messages for now.