### PR TITLE
adjust text spacing and remove warning #368

### DIFF
--- a/vignettes/print_to_ggplot.Rmd
+++ b/vignettes/print_to_ggplot.Rmd
@@ -29,28 +29,28 @@ Print to ggplot outputs a ggplot table. This table can then be added to an exist
 
 A common use case of this function could be in the production of survival plots. The following code sets up a Kaplan Meier plot using the colon data from the survival package. 
 
-```{r, message=FALSE,warning=FALSE}
+```{r, message=FALSE, warning=FALSE}
 # Set up survival data
 fit <- survfit(Surv(time,status)~rx, data=colon)
 
 # Plot kaplan meier between times 0-3000
-km_plot<-autoplot(fit)+
+km_plot <- autoplot(fit) +
   xlim(c(0,3000))
 ```
 
 As with `print_to_gt`, `print_to_ggplot` requires an input table with `label`, `value`,`param` and `column` variables.  The following code sets up our mock input table. 
 
-```{r,message=FALSE,warning=FALSE}
-risk<-tibble(time=c(rep(c(0,1000,2000,3000),3)),
-             label=c(rep("Obs",4),rep("Lev",4),rep("Lev+5FU",4)),
-             value=c(630,372,256,11,620,360,266,8,608,425,328,14),
-             param=rep("n",12))
+```{r, message=FALSE, warning=FALSE}
+risk <- tibble(time=c(rep(c(0,1000,2000,3000),3)),
+               label=c(rep("Obs",4),rep("Lev",4),rep("Lev+5FU",4)),
+               value=c(630,372,256,11,620,360,266,8,608,425,328,14),
+               param=rep("n",12))
 ```
 
 A tfrmt object is required to specify the formatting of the ggplot table. This can then be piped out to `print_to_ggplot` as seen below. 
 
-```{r,message=FALSE,warning=FALSE}
-table <-tfrmt(
+```{r, message=FALSE, warning=FALSE}
+table <- tfrmt(
   # specify columns in the data
   label = label ,
   column = time,
@@ -61,12 +61,13 @@ table <-tfrmt(
                    frmt("X"))
   )) %>%
   print_to_ggplot(risk)
+
 table
 ```
 
-Now using the patchwork package we can combine the original plot, and our ggplot table. Since we want the table below the plot, we use `/`. For more information on using patchwork, refer to the documentation [here](https://cran.r-project.org/web/packages/patchwork/vignettes/patchwork.html)
+Now using the patchwork package we can combine the original plot, and our ggplot table. Since we want the table below the plot, we use `/`. For more information on using patchwork, refer to the documentation [here](https://cran.r-project.org/web/packages/patchwork/vignettes/patchwork.html).
 
-```{r, fig.width=7 ,message=FALSE,warning=FALSE}
+```{r, fig.width=7, message=FALSE, warning=FALSE}
 km_plot/table
 ```
 
@@ -75,7 +76,6 @@ Because we don't have to duplicate the time points, we can just remove the x-axi
 table2 <- table +
   theme(axis.text.x = NULL)
 
-
 km_plot/table2
 ```
 
@@ -83,23 +83,22 @@ km_plot/table2
 
 You can also apply groups to your ggplot table. The code below adds groupings to the risk table above for a mock example. 
 
-```{r,message=FALSE,warning=FALSE}
-riska<- risk %>%
+```{r, message=FALSE, warning=FALSE}
+riska <- risk %>%
   mutate(group="A")
 
-riskb<- risk %>%
+riskb <- risk %>%
   mutate(group="B",
          value=value+10)
 
-risk_group<-riska %>%
+risk_group <- riska %>%
   rbind(riskb)
 ```
 
 Now we need to add group to our tfrmt specification and patch together:
 
-```{r, fig.width=7,message=FALSE,warning=FALSE}
-
-group_table<-tfrmt(
+```{r, fig.width=7, message=FALSE, warning=FALSE}
+group_table <- tfrmt(
   # specify columns in the data
   group = group,
   label = label ,
@@ -114,12 +113,11 @@ group_table<-tfrmt(
   theme(axis.text.x = NULL)
 
 km_plot/group_table
-
 ```
+
 ## Forest Plots
 
 The same logic used in the survival plots can also be used to create forest plots, but instead of stacking the plots we will just put them side by side. First we can make the table using `print_to_ggplot`. 
-
 
 ```{r}
 aes <- factor(c("Fever", "Malaise", "Local Allergic Reaction"),
@@ -140,20 +138,19 @@ tbl_p <- tfrmt_n_pct() %>%
         param = param, 
         value = "value") %>% 
   print_to_ggplot(tbl_dat)
-tbl_p
 
+tbl_p
 ```
 
+Next we need to plot the rate ratios. This plot requires a bit more refining because we need to remove the y-axis label so it can be combined with the table plot. We also need to add a row in the data for the group value to make the plots match up correctly. 
 
-Next we need to plot the rate ratios. This plot requires a bit more finessing because we need to remove the y-axis label so it can be combined with the table plot. Also we need to add a row in the data for the group value to make the plots match up correctly.   
 ```{r, warning=FALSE}
-
 plot_dat <- tibble(
   ae = aes,
   mean = c(3, 2.3, 2),
   lower = c(1.95, 1.9, 1.2),
   upper = c(4, 3.5, 3.4)
-) %>% 
+  ) %>% 
   bind_rows(c(ae = "1 to 7 days after treatment"))
 
 plot_p <- ggplot(data=plot_dat, aes(x=ae, y=mean, ymin=lower, ymax=upper)) +
@@ -165,20 +162,20 @@ plot_p <- ggplot(data=plot_dat, aes(x=ae, y=mean, ymin=lower, ymax=upper)) +
   scale_x_discrete(limits=rev)+
   scale_y_discrete(position = "right") + 
   theme_minimal() +
-  theme(axis.text.y=element_blank(), #remove x axis labels
+  theme(axis.text.y=element_blank(), # remove x axis labels
         axis.ticks.y=element_blank())
 plot_p
 ```
 
 Now thanks to patchwork combining the two plots is relatively easy. 
 
-```{r}
+```{r, warning=FALSE}
 tbl_p + plot_p
 ```
 
 ## Table Styling
 
-A final note about the ggplot tables. Most styling can be adjusted with `theme` once the table is create. But, the table body needs to be adjusted in the `print_to_ggplot` call, by supplying the requirements to the `...`. So if you need to change the size table boy you just add that to the `print_to_ggplot`. 
+A final note about the ggplot tables - most styling can be adjusted with `theme` once the table is create. But, the table body needs to be adjusted in the `print_to_ggplot` call, by supplying the requirements to the `...`. So if you need to change the size table boy you just add that to the `print_to_ggplot`. 
 ```{r}
 tfrmt_n_pct() %>% 
   tfrmt(label = ae,


### PR DESCRIPTION
- adjusted the spacing between text and code
- removed warning for one code chunk
- other code chunks seem to already contain warning=FALSE and/or message=FALSE from previous commits