### PR TITLE
error when col_style_structure without col_style_plan

### DIFF
--- a/R/apply_col_style_plan.R
+++ b/R/apply_col_style_plan.R
@@ -16,6 +16,13 @@ apply_col_style_plan <- function(.data, tfrmt_obj, col_plan_vars = as_vars.chara
 
   style_plan <- tfrmt_obj$col_style_plan
 
+  # check if col_style_plan is part of tfrmt_obj and wrapped by col_style_plan
+  if (!is.null(style_plan)) {
+    if (!inherits(style_plan, "col_style_plan")) {
+      stop("col_style_structure must be wrapped by col_style_plan.")
+    }
+  }
+
   if(is.null(style_plan) || length(style_plan) == 0){
     return(.data)
   }


### PR DESCRIPTION
- added code which checks whether the col_style_plan param of a tfrmt object contains the col_style_plan attribute - if not, then produce custom error message
- used following code to test (to produce error):

```
dat <- tribble(
  ~label     , ~param, ~column    , ~value,   ~ord, 
  "n"        ,"n"     , "trt1"     ,12,        1, 
  "mean (sd)","mean"  , "trt1"     ,12.332837, 2,
  "mean (sd)","sd"    , "trt1"     ,4.3454547, 2,
  "median"   ,"median", "trt1"     ,14,        3, 
  "n"        ,"n"     , "trt2"     ,24,        1,
  "mean (sd)","mean"  , "trt2"     ,15.438737, 2,
  "mean (sd)","sd"    , "trt2"     ,6.723827,  2, 
  "median"   ,"median", "trt2"     ,16,        3, 
  "n"        ,"pval"  , "p-value"  ,NA,        1, 
  "mean (sd)","pval"  , "p-value"  ,0.00002,   2, 
  "median"   ,"pval"  , "p-value"  ,0.051211,  3)

#---

object1 <- tfrmt(
  label = label,
  column = column,
  param = param,
  value = value,
  sorting_cols = c(ord),
  col_plan = col_plan(-ord), 
  body_plan = body_plan(
    frmt_structure(group_val = ".default", label_val = ".default", 
                   frmt("xx", missing = " ")),
    frmt_structure(group_val = ".default", label_val = ".default", 
                   frmt_combine("{mean} ({sd})", 
                                mean = frmt("xx.x"), 
                                sd = frmt("xx.xx"),
                                missing=" ")),
    frmt_structure(group_val = ".default", label_val = ".default", 
                   pval = frmt_when(">0.99" ~ ">0.99",
                                    "<0.001" ~ "<0.001",
                                    "<0.05" ~ frmt("x.xxx*"),
                                    TRUE ~ frmt("x.xxx", missing = "")))
  ), 
  col_style_plan = col_style_plan(
    col_style_structure(col = `p-value`, align = c("."), type = "char")
  )  
) 
object1 %>% 
  print_to_gt(dat)

#---

object2 <- tfrmt(
  label = label,
  column = column,
  param = param,
  value = value,
  sorting_cols = c(ord),
  col_plan = col_plan(-ord), 
  body_plan = body_plan(
    frmt_structure(group_val = ".default", label_val = ".default", 
                   frmt("xx", missing = " ")),
    frmt_structure(group_val = ".default", label_val = ".default", 
                   frmt_combine("{mean} ({sd})", 
                                mean = frmt("xx.x"), 
                                sd = frmt("xx.xx"),
                                missing=" ")),
    frmt_structure(group_val = ".default", label_val = ".default", 
                   pval = frmt_when(">0.99" ~ ">0.99",
                                    "<0.001" ~ "<0.001",
                                    "<0.05" ~ frmt("x.xxx*"),
                                    TRUE ~ frmt("x.xxx", missing = "")))
  ), 
  col_style_plan = col_style_structure(col = `p-value`, align = c("."), type = "char")
  
) 
object2 %>% 
  print_to_gt(dat)
```