### PR TITLE
create check_plan()

### DIFF
--- a/R/tfrmt.R
+++ b/R/tfrmt.R
@@ -197,6 +197,15 @@ tfrmt <- function(
     class = c("tfrmt")
   )
 
+  # check non-null plan parameters are supplied with plan function
+  check_plan(new_tfrmt, "body_plan")
+  check_plan(new_tfrmt, "col_plan")
+  check_plan(new_tfrmt, "col_style_plan")
+  check_plan(new_tfrmt, "row_grp_plan")
+  check_plan(new_tfrmt, "footnote_plan")
+  check_plan(new_tfrmt, "page_plan")
+
+
   if(!missing(tfrmt_obj)){
     new_tfrmt <- layer_tfrmt(
       tfrmt_obj,
@@ -213,6 +222,7 @@ tfrmt <- function(
   check_footnote_plan(new_tfrmt)
 
   new_tfrmt
+  #browser()
 
 }
 

--- a/R/tfrmt_checks.R
+++ b/R/tfrmt_checks.R
@@ -284,3 +284,24 @@ check_footnote_plan <- function(x){
 
 }
 
+
+#' Check if the plan parameter is consistent in tfrmt
+#' @noRd
+#' @param tfrmt_object tfrmt object to be checked
+#' @param plan plan parameter, e.g., col_style_plan
+#' @importFrom rlang abort inherits
+#'
+#'
+check_plan <- function(tfrmt_object, plan) {
+  # extract the plan element from the tfrmt_object
+  plan_element <- tfrmt_object[[plan]]
+
+  # check if the user supplied a value to the plan parameter
+  if (!is.null(plan_element)) {
+    # Check if the plan element inherits the plan attribute
+    if (!inherits(plan_element, plan)) {
+      stop("Check if ", plan, " parameter has been supplied ", plan, "() function")
+    }
+  }
+}
+


### PR DESCRIPTION
- check_plan function to be used in following format: `check_plan(tfrmt_object, "plan")`
- currently used within tfrmt() function
- stops and presents error message when non-null plan not supplied with plan function

The following can be used to test:

```r
dat <- tribble(
  ~group,     ~label,  ~my_col,    ~parm, ~val,
  "g1", "rowlabel1",  "col1"  ,  "value",    1,
  "g1", "rowlabel1",  "col2"  ,  "value",    1,
  "g1", "rowlabel1",  "mycol3",  "value",    1,
  "g1", "rowlabel1",  "col4"  ,  "value",    1,
  "g1", "rowlabel1",  "mycol5",  "value",    1,
  "g1", "rowlabel2",  "col1"  ,  "value",    2,
  "g1", "rowlabel2",  "col2"  ,  "value",    2,
  "g1", "rowlabel2",  "mycol3",  "value",    2,
  "g1", "rowlabel2",  "col4"  ,  "value",    2,
  "g1", "rowlabel2",  "mycol5",  "value",    2,
  "g2", "rowlabel3",  "col1"  ,  "value",    3,
  "g2", "rowlabel3",  "col2"  ,  "value",    3,
  "g2", "rowlabel3",  "mycol3",  "value",    3,
  "g2", "rowlabel3",  "col4"  ,  "value",    3,
  "g2", "rowlabel3",  "mycol5",  "value",    3)

tfrmt(
  group = group,
  label = label,
  param = parm,
  value = val,
  column = my_col,
  # body_plan function supplied
  body_plan = body_plan(frmt_structure(group_val = ".default", label_val = ".default", frmt("x")))
  ) %>% 
  print_to_gt(dat)

tfrmt(
  group = group,
  label = label,
  param = parm,
  value = val,
  column = my_col,
  # body_plan function *not* supplied
  body_plan = frmt_structure(group_val = ".default", label_val = ".default", frmt("x"))
  ) %>% 
  print_to_gt(dat)
```