### PR TITLE
Update print_to_gt.R to put RTF footnotes in the document footer by default 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 # tfrmt development version
 
-# tfrmt 0.1.4
 
 Bug fixes
 * Updated RTF footnotes so they go in the document footer by default.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # tfrmt development version
 
+# tfrmt 0.1.4
+
+Bug fixes
+* Updated RTF footnotes so they go in the document footer by default.
+
 # tfrmt 0.1.3
 
 Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tfrmt development version
 
 
-Bug fixes
+Improvements
 * Updated RTF footnotes so they go in the document footer by default.
 
 # tfrmt 0.1.3

--- a/R/print_to_gt.R
+++ b/R/print_to_gt.R
@@ -266,6 +266,7 @@ cleaned_data_to_gt.default <- function(.data, tfrmt, .unicode_ws){
       table.font.names = c("Courier", default_fonts()),
       page.numbering = TRUE,
       page.header.use_tbl_headings = FALSE,
+      page.footer.use_tbl_notes = TRUE,
       page.orientation = "landscape") %>%
 
     tab_style(


### PR DESCRIPTION
resolves #422 