### PR TITLE
Fix for upcoming purrr 1.2.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/apply_frmt_methods.R
+++ b/R/apply_frmt_methods.R
@@ -278,7 +278,7 @@ apply_frmt.frmt_combine <- function(frmt_def, .data, value, mock = FALSE, param,
 }
 
 #' @export
-#' @importFrom rlang as_label f_rhs f_lhs parse_exprs eval_tidy
+#' @importFrom rlang as_label f_rhs parse_exprs eval_tidy
 #' @importFrom dplyr pull if_else mutate
 #' @importFrom purrr map map_chr keep
 #' @importFrom rlang :=
@@ -313,6 +313,7 @@ apply_frmt.frmt_when <- function(frmt_def, .data, value, mock = FALSE, ...){
         out
       })
 
+    
     left <- frmt_def$frmt_ls %>%
       map_chr(f_lhs) %>%
       if_else(. == "TRUE", ., paste0(values_str, .)) %>%

--- a/R/frmt_utils.R
+++ b/R/frmt_utils.R
@@ -388,3 +388,5 @@ as.character.span_structure <- function(x, ...){
          ")"
   )
 }
+
+f_lhs <- function(x) as.character(rlang::f_lhs(x))


### PR DESCRIPTION
`map_chr()` no longer automatically coerces logical to character.