### PR TITLE
swap formatted spaces for unicode characters

### DIFF
--- a/R/apply_frmt_methods.R
+++ b/R/apply_frmt_methods.R
@@ -34,7 +34,7 @@ apply_frmt <- function(frmt_def, .data, value, mock = FALSE, ...){
 }
 
 
-#' @importFrom stringr str_count str_trim str_dup str_c str_remove str_extract str_detect
+#' @importFrom stringr str_count str_trim str_dup str_c str_remove str_extract str_detect str_replace_all
 #' @importFrom dplyr case_when tibble pull mutate
 #' @importFrom rlang := as_function
 #' @export
@@ -140,6 +140,9 @@ apply_frmt.frmt <- function( frmt_def, .data, value, mock = FALSE, ...){
     } else {
       fmt_val_output <- frmt_def$expression
     }
+
+    # replace spaces with invisible unicode characters
+    fmt_val_output <- str_replace_all(fmt_val_output, pattern = " ", replacement = "\u00A0")
 
     out <- .data %>%
       mutate(

--- a/tests/testthat/test-apply_frmt.R
+++ b/tests/testthat/test-apply_frmt.R
@@ -28,17 +28,17 @@ test_that("applying frmt", {
 
   expect_equal(
     sample_df_no_dec_frmted$x,
-    c("1235", "346", " 57", "4568", "  9")
+    c("1235", "346", "\u00A057", "4568", "\u00A0\u00A09")
   )
 
   expect_equal(
     sample_df_single_dec_frmted$x,
-    c("1234.6", "345.7", " 56.8", "4567.9", "  8.9")
+    c("1234.6", "345.7", "\u00A056.8", "4567.9", "\u00A0\u00A08.9")
   )
 
   expect_equal(
     sample_df_double_dec_frmted$x,
-    c("1234.57", "345.68", " 56.79", "4567.89", "  8.91")
+    c("1234.57", "345.68", "\u00A056.79", "4567.89", "\u00A0\u00A08.91")
   )
 
 })
@@ -80,22 +80,22 @@ test_that("applying frmt - scientific", {
 
   expect_equal(
     sample_df_frmted_10x$x,
-    c("  1.2 x10^3",
-      "  3.5 x10^2",
-      "  5.7 x10^1",
-      "  4.6 x10^3",
-      "  8.9 x10^0",
-      "  6.8 x10^-2")
+    c("\u00A0\u00A01.2\u00A0x10^3",
+      "\u00A0\u00A03.5\u00A0x10^2",
+      "\u00A0\u00A05.7\u00A0x10^1",
+      "\u00A0\u00A04.6\u00A0x10^3",
+      "\u00A0\u00A08.9\u00A0x10^0",
+      "\u00A0\u00A06.8\u00A0x10^-2")
   )
 
   expect_equal(
     sample_df_frmted_10xx$x,
-    c("  1.2 x10^ 3",
-      "  3.5 x10^ 2",
-      "  5.7 x10^ 1",
-      "  4.6 x10^ 3",
-      "  8.9 x10^ 0",
-      "  6.8 x10^-2")
+    c("\u00A0\u00A01.2\u00A0x10^\u00A03",
+      "\u00A0\u00A03.5\u00A0x10^\u00A02",
+      "\u00A0\u00A05.7\u00A0x10^\u00A01",
+      "\u00A0\u00A04.6\u00A0x10^\u00A03",
+      "\u00A0\u00A08.9\u00A0x10^\u00A00",
+      "\u00A0\u00A06.8\u00A0x10^-2")
   )
 
   expect_equal(


### PR DESCRIPTION
Just experimenting to see if this is the direction we want to go before I update all the tests etc



This is to resolve the issue here: https://github.com/GSK-Biostatistics/tfrmt/issues/530 which means that double spaces in the formatting collapse when output to pdf. 

With reprex in the issue: 
Before:

<img width="276" height="255" alt="image" src="https://github.com/user-attachments/assets/6f71392e-26a3-4c6d-ac42-97893f774569" />

After:
<img width="209" height="187" alt="image" src="https://github.com/user-attachments/assets/56c6473b-93ed-486d-a1c1-33c1505def51" />
