### PR TITLE
Closes #642: Apply fix for column headers containing parenthesis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## Bug fixes
 * Fix bug in `tfrmt_sigdig` so it correctly passes the 'missing' argument to the body_plan (#621, @alanahjonas95).
 * Fix bug in `page_plan` where the max_rows argument was returning an error if a value in the group variable was an empty string (#539, @alanahjonas95).
-
+* Fix bug in `as.character.span_structure` where the regex was incorrectly capturing content wrapped in parentheses as an R function even though it did not have a valid R function identifier immediately before the `(`. i.e., "n (%)" incorrectly captured as a function. (#643)
+  
 ## Improvements
 * `footnote_plan()` receives a new argument, `order`, allowing users to specify the order of footnotes (#605, @alanahjonas95).
 * Add markdown processing of stub column labels (#617)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 * Fix bug in `tfrmt_sigdig` so it correctly passes the 'missing' argument to the body_plan (#621, @alanahjonas95).
 * Fix bug in `page_plan` where the max_rows argument was returning an error if a value in the group variable was an empty string (#539, @alanahjonas95).
-* Fix bug in `as.character.span_structure` where the regex was incorrectly capturing content wrapped in parentheses as an R function even though it did not have a valid R function identifier immediately before the `(`. i.e., "n (%)" incorrectly captured as a function. (#643, @LiamHobby)
+* Fix bug in `as.character.span_structure` where the regex was incorrectly capturing content wrapped in parentheses as an R function even though it did not have a valid R function identifier immediately before the `(`. i.e., "n (%)" incorrectly captured as a function (#643, @LiamHobby).
   
 ## Improvements
 * `footnote_plan()` receives a new argument, `order`, allowing users to specify the order of footnotes (#605, @alanahjonas95).

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 * Fix bug in `tfrmt_sigdig` so it correctly passes the 'missing' argument to the body_plan (#621, @alanahjonas95).
 * Fix bug in `page_plan` where the max_rows argument was returning an error if a value in the group variable was an empty string (#539, @alanahjonas95).
-* Fix bug in `as.character.span_structure` where the regex was incorrectly capturing content wrapped in parentheses as an R function even though it did not have a valid R function identifier immediately before the `(`. i.e., "n (%)" incorrectly captured as a function. (#643)
+* Fix bug in `as.character.span_structure` where the regex was incorrectly capturing content wrapped in parentheses as an R function even though it did not have a valid R function identifier immediately before the `(`. i.e., "n (%)" incorrectly captured as a function. (#643, @LiamHobby)
   
 ## Improvements
 * `footnote_plan()` receives a new argument, `order`, allowing users to specify the order of footnotes (#605, @alanahjonas95).

--- a/R/frmt_utils.R
+++ b/R/frmt_utils.R
@@ -368,8 +368,10 @@ as.character.span_structure <- function(x, ...){
       elements <- map_chr(val, as_label) %>%
         str_replace_all("\\\"", "'")
 
+      # Detect function calls. Matches valid R functions i.e, my_function()
+      # Valid column names containing parenthesis i.e., "n (%)" are not captured
       not_fxs <-elements %>%
-        str_which("\\(.+\\)", negate = TRUE)
+        str_which("^[A-Za-z_.][A-Za-z0-9_.]*\\(", negate = TRUE)
       elements[not_fxs] <- elements[not_fxs] %>%
         str_c("'", ., "'")
 

--- a/tests/testthat/test-JSON.R
+++ b/tests/testthat/test-JSON.R
@@ -672,3 +672,27 @@ test_that("json read/write", {
   file.remove(test_loc)
 
 })
+
+test_that("json col_plan span_structure roundtrip with parentheses in column names", {
+  span_parenthesis <- tfrmt(
+    group = group1,
+    label = label,
+    param = statistic,
+    value = value,
+    column = c(span, column),
+    col_plan = col_plan(
+      group1,
+      label,
+      span_structure(span = "Placebo",              column = c("n (%)", "evt")),
+      span_structure(span = "Xanomeline Low Dose",  column = c("n (%)", "evt")),
+      span_structure(span = "Xanomeline High Dose", column = c("n (%)", "evt")),
+      span_structure(span = "Total",                column = c("n (%)", "evt")),
+      .drop = TRUE
+    )
+  )
+
+  span_parenthesis |>
+    tfrmt_to_json()|>
+    json_to_tfrmt(json = _) |>
+    expect_equal(span_parenthesis, ignore_attr = TRUE)
+})


### PR DESCRIPTION
Closes #642 

**Summary of changes**
`json_to_tfrmt` threw a parse error when reading a `col_plan` that contained `span_structure` elements whose column names contained parenthesis i.e., "n (%)".

`as.character.span_structure()` converts a `span_structure` to a character string so it can be converted to JSON. Plain column names are quoted `"evt" -> 'evt'` but function calls should not be quoted. The existing regex `\\(.+\\) captured any string containing `(something)`.

"n (%)" contains "(%)" so it matched the regex and was incorrectly treated as a function call which then fails to evaluate in `parse_expr()`.

The new regex matches only strings that start with a valid R function identifier followed immediately by a parenthesis (no space between the name and the `(`.

New test added for round trip validation `tfrmt` -> `json` -> `tfrmt`.

**Note for the reviewer**
Running `devtools::test()` causes three snapshot failures in the file `test-shuffle_card.R` using `cards` version 0.8.0.
<img width="509" height="146" alt="image" src="https://github.com/user-attachments/assets/4afe3f8e-9e90-4d63-a5b7-1b94de8ba2bb" />

Downgrading to version 0.7.1 passes all tests:
<img width="456" height="142" alt="image" src="https://github.com/user-attachments/assets/77d805bd-c54b-400a-aba7-788dae89a8ae" />


**R CMD Check passes**
<img width="973" height="79" alt="image" src="https://github.com/user-attachments/assets/09487b23-1c35-4ccc-a0b5-22d150217211" />

