### PR TITLE
fix for unlisted_card class added in cards

### DIFF
--- a/R/prep_card.R
+++ b/R/prep_card.R
@@ -45,7 +45,6 @@ prep_info_return <- "Unable to apply {.fn {prep_func}}."
 #' )
 prep_combine_vars <- function(df, vars, remove = TRUE) {
 
-  class_uncards <- class(df)
   if (!rlang::is_character(vars)) {
     cli::cli_abort(
       "{.arg vars} must be a character vector. You have supplied \\
@@ -131,7 +130,6 @@ prep_combine_vars <- function(df, vars, remove = TRUE) {
       "variable_level" = "var_level_untd",
     )
 
-  class(output) <- class_uncards
   output
 }
 

--- a/R/prep_card.R
+++ b/R/prep_card.R
@@ -45,6 +45,7 @@ prep_info_return <- "Unable to apply {.fn {prep_func}}."
 #' )
 prep_combine_vars <- function(df, vars, remove = TRUE) {
 
+  class_uncards <- class(df)
   if (!rlang::is_character(vars)) {
     cli::cli_abort(
       "{.arg vars} must be a character vector. You have supplied \\
@@ -130,6 +131,7 @@ prep_combine_vars <- function(df, vars, remove = TRUE) {
       "variable_level" = "var_level_untd",
     )
 
+  class(output) <- class_uncards
   output
 }
 

--- a/tests/testthat/test-prep_card.R
+++ b/tests/testthat/test-prep_card.R
@@ -220,7 +220,8 @@ test_that("prep_...() pipe with demographic data", {
 
   expect_identical(
     dplyr::arrange(ard_tbl, ord1, ord2),
-    dplyr::arrange(prepped_ard, ord1, ord2)
+    dplyr::arrange(prepped_ard, ord1, ord2),
+    ignore_attr = "class"
   )
 
   expect_no_error(


### PR DESCRIPTION
based on this update in cards test in test-prepcard was failing, line 221 https://github.com/GSK-Biostatistics/tfrmt/blob/f0dd68c7e53e4ebdc1ca5062ece37281af31c60a/tests/testthat/test-prep_card.R#L221

https://github.com/insightsengineering/cards/commit/8a0307433a407479aff0996c2db360993264f610

the new card_unlisted class was getting dropped in the `prep_combine_vars` function, so i have updated to keep this class.