### PR TITLE
fix bug in shuffle card preventing by attribute  being passed after  …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,6 @@ Suggests:
     survival,
     testthat (>= 3.0.0),
     withr
-Remotes: 
-    insightsengineering/cards
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     tidyr,
     tidyselect
 Suggests:
-    cards (>= 0.8.1),
+    cards (>= 0.8.0),
     covr,
     ggfortify,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     tidyr,
     tidyselect
 Suggests:
-    cards (>= 0.8.0),
+    cards (>= 0.8.1),
     covr,
     ggfortify,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 * Add markdown processing of stub column labels (#617)
 * Update default for `row_grp_plan()`/`row_grp_structure()` to remove trailing post-space rows (#630, @alanahjonas95).
 * Added `extract_data()` function to enable data to be easily extracted from a tfrmt into a data frame.(#628, @alanahjonas95)
-
+* `shuffle_card()` now explicitly handles `bind_ard` attributes, prioritising the user-supplied `by` argument over inherited ARD attributes and providing clearer warning messages during mismatches (#650, @alanahjonas95).
 
 # tfrmt 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@
 * Add markdown processing of stub column labels (#617)
 * Update default for `row_grp_plan()`/`row_grp_structure()` to remove trailing post-space rows (#630, @alanahjonas95).
 * Added `extract_data()` function to enable data to be easily extracted from a tfrmt into a data frame.(#628, @alanahjonas95)
-* `shuffle_card()` now explicitly handles `bind_ard` attributes, prioritising the user-supplied `by` argument over inherited ARD attributes and providing clearer warning messages during mismatches (#650, @alanahjonas95).
+* `shuffle_card()` now automatically strips inherited ARD attributes from objects of class `bind_ard` to avoid unreliable metadata (#650).
+* `shuffle_card()` now prioritises the user-supplied `by` argument over inherited ARD attributes, giving users control to override attributes and updating the mismatch message to reflect this change (#650).
 
 # tfrmt 0.3.0
 

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -64,11 +64,13 @@ shuffle_card <- function(x,
 
   # If a combined ARD is passed, drop stale attributes and evaluate structurally
   if (inherits(x, "bind_ard") && !is.null(attr(x, "args"))) {
+    if (!is.null(by)) {
       attr(x, "args")$by <- NULL
+    }
       attr(x, "args")$variable <- NULL
       attr(x, "args")$strata <- NULL
   }
-
+  
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
 

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -200,7 +200,7 @@ shuffle_card <- function(x,
       cli::cli_inform(
         c("Mismatch between attributes of {.arg x} and supplied value to {.arg by}.",
           "i" = "Supplied value will be used in lieu of attributes.",
-          "*" = "Note: As of {.pkg tfrmt} v0.4.0, explicitly supplied {.arg by} values take priority over data frame attributes."),
+          "*" = "Note: As of {.pkg tfrmt} v0.4.0, explicitly supplied {.arg by} values take priority over the {.cls card} attributes."),
         env = rlang::caller_env()
       )
     }

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -72,6 +72,13 @@ shuffle_card <- function(x,
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
 
+  # Check if a 'by' variable is available
+  if (is.null(by) || length(by) == 0) {
+    cli::cli_abort(
+       "The {.arg by} argument was not supplied."
+      )
+  }
+
   # make sure columns are in order & add index for retaining order
   if (isTRUE(order_rows)){
     x <- x |>

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -391,7 +391,7 @@ shuffle_card <- function(x,
   output <- dplyr::case_when(
     x == "..cards_overall.." ~ overall_val,
     x == "..hierarchical_overall.." ~ any_val,
-    TRUE ~ x
+    TRUE ~ as.character(x)
   )
 
   output

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -189,7 +189,7 @@ shuffle_card <- function(x,
 #' Process `by` variable
 #'
 #' @param x a data frame
-#' @param by Grouping variable(s) used in calculations. Defaults to `NULL`.
+#' @param by Grouping variable(s) used in calculations. 
 #'
 #' @returns character string if `by` variable present
 #' @noRd

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -44,13 +44,15 @@ shuffle_card <- function(x,
                          fill_overall = "Overall {colname}",
                          fill_hierarchical_overall = "Any {colname}") {
 
-  rlang::check_installed("cards")
+  rlang::check_installed(
+    pkg = "cards",
+    version = "0.8.1",
+    compare = ">=",
+    reason = "for compatibility with tfrmt v0.4.0"
+  )
 
-  if (!inherits(x, "card")) {
-    cli::cli_abort(
-      "{.arg x} argument must be class {.cls card}, not {.obj_type_friendly {x}}"
-    )
-  }
+  check_card(x)
+
   if (!inherits(trim, "logical")) {
     cli::cli_abort(
       "{.arg trim} argument must be class {.cls logical}}, not \\
@@ -59,7 +61,7 @@ shuffle_card <- function(x,
   }
 
   # Check if a 'by' variable is available
-  if (is_bind_ard_cards(x) && rlang::is_empty(by)) {
+  if (is_bind_ard_card(x) && rlang::is_empty(by)) {
     cli::cli_inform(
       c(
         "The {.arg by} argument was not supplied.",
@@ -69,7 +71,7 @@ shuffle_card <- function(x,
     )
   }
 
-  x <- drop_bind_ard_attr(x)
+  x <- drop_bind_ard_args(x)
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
 
@@ -191,22 +193,28 @@ shuffle_card <- function(x,
 #'
 #' @returns character string if `by` variable present
 #' @noRd
-.process_by <- function(x, by){
+.process_by <- function(x, by) {
+  by_arg <- get_card_attr_arg(x, "by")
 
-  ard_attributes <- attributes(x)
-  ard_args <- ard_attributes$args
-  if (!is.null(by)){
-    if (!is.null(ard_args$by) && !identical(ard_args$by, by)){
+  # 1. If 'by' is explicitly supplied, it takes absolute priority
+  if (!is.null(by)) {
+    # Only warn if an attribute actually exists AND it doesn't match
+    if (!is.null(by_arg) && !identical(by_arg, by)) {
       cli::cli_inform(
-        c("Mismatch between attributes of {.arg x} and supplied value to {.arg by}.",
+        c(
+          "Mismatch between attributes of {.arg x} and supplied value to {.arg by}.",
           "i" = "Supplied value will be used in lieu of attributes.",
-          "*" = "Note: As of {.pkg tfrmt} v0.4.0, explicitly supplied {.arg by} values take priority over the {.cls card} attributes."),
+          "*" = "Note: As of {.pkg tfrmt} v0.4.0, explicitly supplied {.arg by} \\
+                 values take priority over data frame attributes."
+        ),
         env = rlang::caller_env()
       )
     }
     return(by)
   }
-  ard_args$by
+
+  # 2. If 'by' was NOT supplied, fall back to the attribute
+  by_arg
 }
 
 #' Fill Overall Group Variables

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -64,13 +64,11 @@ shuffle_card <- function(x,
 
   # If a combined ARD is passed, drop stale attributes and evaluate structurally
   if (inherits(x, "bind_ard") && !is.null(attr(x, "args"))) {
-    if (!is.null(by)) {
       attr(x, "args")$by <- NULL
-    }
       attr(x, "args")$variable <- NULL
       attr(x, "args")$strata <- NULL
   }
-  
+
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
 

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -64,7 +64,7 @@ shuffle_card <- function(x,
   if (is_bind_ard_card(x) && rlang::is_empty(by)) {
     cli::cli_inform(
       c(
-        "The {.arg by} argument was not supplied.",
+        "The {.arg by} argument was not supplied and cannot be inferred from objects of class {.cls bind_ard}.",
         "i" = "When using a combined ARD ({.cls bind_ard}) individual grouping attributes are dropped.",
         "*" = "If you want to use a grouping variable, you'll need to pass it explicitly, e.g., {.code shuffle_card(by = 'TRT01A')}."
       )

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -60,10 +60,11 @@ shuffle_card <- function(x,
 
   # Check if a 'by' variable is available
   if (is_bind_ard_cards(x) && rlang::is_empty(by)) {
-    cli::cli_abort(
+    cli::cli_inform(
       c(
         "The {.arg by} argument was not supplied.",
-        "i" = "When using a combined ARD ({.cls bind_ard}), you must explicitly pass a grouping variable, e.g., {.code shuffle_card(by = 'TRT01A')}."
+        "i" = "When using a combined ARD ({.cls bind_ard}) individual grouping attributes are dropped.",
+        "*" = "If you want to use a grouping variable, you'll need to pass it explicitly, e.g., {.code shuffle_card(by = 'TRT01A')}."
       )
     )
   }

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -65,7 +65,6 @@ shuffle_card <- function(x,
     cli::cli_inform(
       c(
         "The {.arg by} argument was not supplied and cannot be inferred from objects of class {.cls bind_ard}.",
-        "i" = "When using a combined ARD ({.cls bind_ard}) individual grouping attributes are dropped.",
         "*" = "If you want to use a grouping variable, you'll need to pass it explicitly, e.g., {.code shuffle_card(by = 'TRT01A')}."
       )
     )
@@ -189,7 +188,7 @@ shuffle_card <- function(x,
 #' Process `by` variable
 #'
 #' @param x a data frame
-#' @param by Grouping variable(s) used in calculations. 
+#' @param by Grouping variable(s) used in calculations.
 #'
 #' @returns character string if `by` variable present
 #' @noRd

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -73,9 +73,12 @@ shuffle_card <- function(x,
   by <- .process_by(x, by)
 
   # Check if a 'by' variable is available
-  if (is.null(by) || length(by) == 0) {
+  if (inherits(x, "bind_ard") && (is.null(by) || length(by) == 0)) {
     cli::cli_abort(
-       "The {.arg by} argument was not supplied."
+      c(
+        "The {.arg by} argument was not supplied.",
+        "i" = "When using a combined ARD ({.cls bind_ard}), you must explicitly pass a grouping variable, e.g., {.code shuffle_card(by = 'TRT01A')}."
+      )
       )
   }
 

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -62,6 +62,16 @@ shuffle_card <- function(x,
     )
   }
 
+  # Check if a 'by' variable is available
+  if (inherits(x, "bind_ard") && (is.null(by) || length(by) == 0)) {
+    cli::cli_abort(
+      c(
+        "The {.arg by} argument was not supplied.",
+        "i" = "When using a combined ARD ({.cls bind_ard}), you must explicitly pass a grouping variable, e.g., {.code shuffle_card(by = 'TRT01A')}."
+      )
+    )
+  }
+
   # If a combined ARD is passed, drop stale attributes and evaluate structurally
   if (inherits(x, "bind_ard") && !is.null(attr(x, "args"))) {
       attr(x, "args")$by <- NULL
@@ -71,16 +81,6 @@ shuffle_card <- function(x,
 
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
-
-  # Check if a 'by' variable is available
-  if (inherits(x, "bind_ard") && (is.null(by) || length(by) == 0)) {
-    cli::cli_abort(
-      c(
-        "The {.arg by} argument was not supplied.",
-        "i" = "When using a combined ARD ({.cls bind_ard}), you must explicitly pass a grouping variable, e.g., {.code shuffle_card(by = 'TRT01A')}."
-      )
-      )
-  }
 
   # make sure columns are in order & add index for retaining order
   if (isTRUE(order_rows)){

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -44,11 +44,7 @@ shuffle_card <- function(x,
                          fill_overall = "Overall {colname}",
                          fill_hierarchical_overall = "Any {colname}") {
 
-  if (!requireNamespace("cards", quietly = TRUE)) {
-    cli::cli_abort(
-      "The {.pkg cards} package must be installed to use {.fn shuffle_card}."
-    )
-  }
+  rlang::check_installed("cards")
 
   if (!inherits(x, "card")) {
     cli::cli_abort(
@@ -63,7 +59,7 @@ shuffle_card <- function(x,
   }
 
   # Check if a 'by' variable is available
-  if (inherits(x, "bind_ard") && (is.null(by) || length(by) == 0)) {
+  if (is_bind_ard_cards(x) && rlang::is_empty(by)) {
     cli::cli_abort(
       c(
         "The {.arg by} argument was not supplied.",
@@ -72,13 +68,7 @@ shuffle_card <- function(x,
     )
   }
 
-  # If a combined ARD is passed, drop stale attributes and evaluate structurally
-  if (inherits(x, "bind_ard") && !is.null(attr(x, "args"))) {
-      attr(x, "args")$by <- NULL
-      attr(x, "args")$variable <- NULL
-      attr(x, "args")$strata <- NULL
-  }
-
+  x <- drop_bind_ard_attr(x)
   ard_args <- attributes(x)$args
   by <- .process_by(x, by)
 
@@ -207,16 +197,17 @@ shuffle_card <- function(x,
   if (!is.null(by)){
     if (!is.null(ard_args$by) && !identical(ard_args$by, by)){
       cli::cli_inform(
-        "Mismatch between attributes of {.arg x} and supplied value to \\
-        {.arg by}. Attributes will be used in lieu of {.arg by}",
-        env = rlang::caller_env())
-    } else {
-      ard_args$by <- by
+        c("Mismatch between attributes of {.arg x} and supplied value to {.arg by}.",
+          "i" = "Supplied value will be used in lieu of attributes.",
+          "*" = "Note: As of {.pkg tfrmt} v0.4.0, explicitly supplied {.arg by} values take priority over data frame attributes."),
+        env = rlang::caller_env()
+      )
     }
+    return(by)
   }
-
   ard_args$by
 }
+
 #' Fill Overall Group Variables
 #'
 #' This function fills the missing values of grouping variables with

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -46,7 +46,7 @@ shuffle_card <- function(x,
 
   rlang::check_installed(
     pkg = "cards",
-    version = "0.8.1",
+    version = "0.8.0",
     compare = ">=",
     reason = "for compatibility with tfrmt v0.4.0"
   )

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -198,7 +198,7 @@ shuffle_card <- function(x,
 
   # 1. If 'by' is explicitly supplied, it takes absolute priority
   if (!is.null(by)) {
-    # Only warn if an attribute actually exists AND it doesn't match
+    # Only inform if an attribute actually exists AND it doesn't match
     if (!is.null(by_arg) && !identical(by_arg, by)) {
       cli::cli_inform(
         c(

--- a/R/utils_cards.R
+++ b/R/utils_cards.R
@@ -1,0 +1,36 @@
+#' Check if an object inherits from 'bind_ard'
+#'
+#' @param x An object to check.
+#' @return `TRUE` if the object inherits from 'bind_ard', `FALSE` otherwise.
+#' @noRd
+is_bind_ard_cards <- function(x) {
+  inherits(x, "bind_ard")
+}
+
+#' Set a specific parameter inside an object's 'args' attribute
+#'
+#' @param x An object.
+#' @param name A string naming the element to modify inside the 'args' attribute list.
+#' @param value The value to assign to that element (e.g., NULL to drop it).
+#' @return The modified object.
+#' @noRd
+set_card_attr <- function(x, name, value) {
+  attr(x, "args")[[name]] <- value
+  x
+}
+
+#' Drop stale attributes from a combined ARD object
+#'
+#' @param x An object to check and modify.
+#' @return The modified object with stale attributes removed if it inherits
+#'   from 'bind_ard' and contains an 'args' attribute.
+#' @noRd
+drop_bind_ard_attr <- function(x) {
+  if (is_bind_ard_cards(x) && !is.null(attr(x, "args"))) {
+    x <- set_card_attr(x, "by", NULL)
+    x <- set_card_attr(x, "variable", NULL)
+    x <- set_card_attr(x, "strata", NULL)
+  }
+
+  x
+}

--- a/R/utils_cards.R
+++ b/R/utils_cards.R
@@ -1,10 +1,70 @@
+#' Check if an object is a card
+#'
+#' Validates that the input is a valid `card` object. If the check fails,
+#' it throws an informative error message using [rlang::stop_input_type()].
+#'
+#' @param card An object to check.
+#' @param arg Character string specifying the argument name to display in error messages.
+#' @param call The execution environment for error backtraces.
+#' @param allow_null Logical indicating whether `NULL` should be accepted as a valid input.
+#'
+#' @return Invisible `NULL` if validation passes, otherwise throws an error.
+#' @noRd
+check_card <- function(
+    card,
+    arg = rlang::caller_arg(card),
+    call = rlang::caller_env(),
+    allow_null = FALSE
+) {
+  if (!missing(card)) {
+    if (is_card(card)) {
+      return(invisible(NULL))
+    }
+
+    if (allow_null && is.null(card)) {
+      return(invisible(NULL))
+    }
+  }
+
+  rlang::stop_input_type(
+    card,
+    "a card object",
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+#' Test if an object is a card
+#'
+#' Checks whether an object inherits from the `"card"` class.
+#'
+#' @param x An object to test.
+#'
+#' @return Logical `TRUE` if the object is a card, `FALSE` otherwise.
+#' @noRd
+is_card <- function(x) {
+  inherits(x, "card")
+}
+
 #' Check if an object inherits from 'bind_ard'
 #'
 #' @param x An object to check.
 #' @return `TRUE` if the object inherits from 'bind_ard', `FALSE` otherwise.
 #' @noRd
-is_bind_ard_cards <- function(x) {
+is_bind_ard_card <- function(x) {
   inherits(x, "bind_ard")
+}
+
+#' Extract an argument from card attributes
+#'
+#' @param x a card object (data frame)
+#' @param arg character string of the argument to extract. Defaults to `"by"`.
+#'
+#' @returns the value of the argument, or `NULL` if not found
+#' @noRd
+get_card_attr_arg <- function(x, arg = "by") {
+  attr(x, "args")[[arg]]
 }
 
 #' Set a specific parameter inside an object's 'args' attribute
@@ -14,7 +74,7 @@ is_bind_ard_cards <- function(x) {
 #' @param value The value to assign to that element (e.g., NULL to drop it).
 #' @return The modified object.
 #' @noRd
-set_card_attr <- function(x, name, value) {
+set_card_args <- function(x, name, value) {
   attr(x, "args")[[name]] <- value
   x
 }
@@ -25,11 +85,11 @@ set_card_attr <- function(x, name, value) {
 #' @return The modified object with stale attributes removed if it inherits
 #'   from 'bind_ard' and contains an 'args' attribute.
 #' @noRd
-drop_bind_ard_attr <- function(x) {
-  if (is_bind_ard_cards(x) && !is.null(attr(x, "args"))) {
-    x <- set_card_attr(x, "by", NULL)
-    x <- set_card_attr(x, "variable", NULL)
-    x <- set_card_attr(x, "strata", NULL)
+drop_bind_ard_args <- function(x) {
+  if (is_bind_ard_card(x) && !is.null(attr(x, "args"))) {
+    x <- set_card_args(x, "by", NULL)
+    x <- set_card_args(x, "variable", NULL)
+    x <- set_card_args(x, "strata", NULL)
   }
 
   x

--- a/tests/testthat/_snaps/shuffle_card.md
+++ b/tests/testthat/_snaps/shuffle_card.md
@@ -115,7 +115,11 @@
       shuffle_card(dplyr::filter(cards::bind_ard(cards::ard_continuous(cards::ADSL,
       by = "ARM", variables = "AGE", statistic = ~ cards::continuous_summary_fns(
         "mean")), dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p",
-        stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L), by = "ARM")
+        stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L))
+    Message
+      The `by` argument was not supplied and cannot be inferred from objects of class <bind_ard>.
+      i When using a combined ARD (<bind_ard>) individual grouping attributes are dropped.
+      * If you want to use a grouping variable, you'll need to pass it explicitly, e.g., `shuffle_card(by = 'TRT01A')`.
     Output
       # A tibble: 4 x 7
         ARM                  AGE      context stat_variable stat_name stat_label  stat

--- a/tests/testthat/_snaps/shuffle_card.md
+++ b/tests/testthat/_snaps/shuffle_card.md
@@ -109,13 +109,13 @@
       7 Overall AGEGR1 continuous AGEGR1        min       Min        65-80
       8 Overall AGEGR1 continuous AGEGR1        max       Max        >80  
 
-# shuffle_card fills missing group levels if the group is meaningful
+# shuffle_card correctly handles a combined ARD when by is explicitly supplied
 
     Code
       shuffle_card(dplyr::filter(cards::bind_ard(cards::ard_continuous(cards::ADSL,
       by = "ARM", variables = "AGE", statistic = ~ cards::continuous_summary_fns(
         "mean")), dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p",
-        stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L))
+        stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L), by = "ARM")
     Output
       # A tibble: 4 x 7
         ARM                  AGE      context stat_variable stat_name stat_label  stat
@@ -131,7 +131,7 @@
       shuffle_card(dplyr::filter(cards::bind_ard(cards::ard_continuous(cards::ADSL,
       variables = "AGE", statistic = ~ cards::continuous_summary_fns("mean")), dplyr::tibble(
         group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(
-          0.05))), dplyr::row_number() <= 5L))
+          0.05))), dplyr::row_number() <= 5L), by = "ARM")
     Output
       # A tibble: 2 x 7
         ARM         AGE         context    stat_variable stat_name stat_label  stat

--- a/tests/testthat/_snaps/shuffle_card.md
+++ b/tests/testthat/_snaps/shuffle_card.md
@@ -118,7 +118,6 @@
         stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L))
     Message
       The `by` argument was not supplied and cannot be inferred from objects of class <bind_ard>.
-      i When using a combined ARD (<bind_ard>) individual grouping attributes are dropped.
       * If you want to use a grouping variable, you'll need to pass it explicitly, e.g., `shuffle_card(by = 'TRT01A')`.
     Output
       # A tibble: 4 x 7

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -74,7 +74,21 @@ test_that("shuffle_card notifies user about warnings/errors before dropping", {
   )
 })
 
-test_that("shuffle_card fills missing group levels if the group is meaningful", {
+test_that("shuffle_card throws an error if bind_ard is used without a supplied by argument", {
+  # Create a combined ARD
+  combined_ard <- cards::bind_ard(
+    cards::ard_continuous(cards::ADSL, by = "ARM", variables = "AGE", statistic = ~ cards::continuous_summary_fns("mean")),
+    dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(0.05))
+  )
+
+  # Verify that the function throws the exact expected error message
+  expect_error(
+    shuffle_card(combined_ard),
+    regexp = "The `by` argument was not supplied"
+  )
+})
+
+test_that("shuffle_card correctly handles a combined ARD when by is explicitly supplied", {
   # mix of missing/nonmissing group levels present before shuffle
   expect_snapshot(
     cards::bind_ard(
@@ -82,7 +96,7 @@ test_that("shuffle_card fills missing group levels if the group is meaningful", 
       dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(0.05))
     ) |>
       dplyr::filter(dplyr::row_number() <= 5L) |>
-      shuffle_card()
+      shuffle_card(by="ARM")
   )
 
   # no group levels present before shuffle
@@ -92,7 +106,7 @@ test_that("shuffle_card fills missing group levels if the group is meaningful", 
       dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(0.05))
     ) |>
       dplyr::filter(dplyr::row_number() <= 5L) |>
-      shuffle_card()
+      shuffle_card(by="ARM")
   )
 
   # mix of group variables - fills overall only if variable has been calculated by group elsewhere

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -96,7 +96,7 @@ test_that("shuffle_card correctly handles a combined ARD when by is explicitly s
       dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(0.05))
     ) |>
       dplyr::filter(dplyr::row_number() <= 5L) |>
-      shuffle_card(by="ARM")
+      shuffle_card()
   )
 
   # no group levels present before shuffle

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -82,7 +82,7 @@ test_that("shuffle_card throws an error if bind_ard is used without a supplied b
   )
 
   # Verify that the function throws the exact expected error message
-  expect_error(
+  expect_message(
     shuffle_card(combined_ard),
     regexp = "The `by` argument was not supplied"
   )

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -81,7 +81,7 @@ test_that("shuffle_card message if bind_ard is used without a supplied by argume
     dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p", stat_label = "p", stat = list(0.05))
   )
 
-  # Verify that the function throws the exact expected error message
+  # Verify that the function throws the exact expected message
   expect_message(
     shuffle_card(combined_ard),
     regexp = "The `by` argument was not supplied"

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -594,10 +594,18 @@ test_that("shuffle_card() prioritizes supplied `by` and messages on mismatch", {
   ard_mismatch <- cards::ard_continuous(cards::ADSL, by = "SEX", variables = "AGE")
   attr(ard_mismatch, "args")$by <- "ARM"
 
-  # This will trigger the mismatch warning but successfully use "SEX" for processing
-  expect_snapshot(
-    res_mismatch <- shuffle_card(ard_mismatch, by = "SEX")
+  # Capture the raw console text sent to the message/stderr stream
+  msg_output <- capture.output(
+    res_mismatch <- shuffle_card(ard_mismatch, by = "SEX"),
+    type = "message"
   )
+  msg_string <- paste(msg_output, collapse = "\n")
+
+  # Programmatically verify the exact elements of your message text
+  expect_match(msg_string, "Mismatch between attributes of")
+  expect_match(msg_string, "Supplied value will be used in lieu of attributes")
+  expect_match(msg_string, "As of tfrmt v0.4.0")
+
   # Verify "SEX" was used as the column name instead of "ARM"
   expect_true("SEX" %in% names(res_mismatch))
   expect_false("ARM" %in% names(res_mismatch))

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -74,7 +74,7 @@ test_that("shuffle_card notifies user about warnings/errors before dropping", {
   )
 })
 
-test_that("shuffle_card throws an error if bind_ard is used without a supplied by argument", {
+test_that("shuffle_card message if bind_ard is used without a supplied by argument", {
   # Create a combined ARD
   combined_ard <- cards::bind_ard(
     cards::ard_continuous(cards::ADSL, by = "ARM", variables = "AGE", statistic = ~ cards::continuous_summary_fns("mean")),

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -588,3 +588,30 @@ test_that("shuffle_card() sorting option", {
     ignore_attr = TRUE
   )
 })
+
+test_that("shuffle_card() prioritizes supplied `by` and messages on mismatch", {
+  # 1. Mismatch: Create an ARD by "SEX", but intentionally spoof the attribute to "ARM"
+  ard_mismatch <- cards::ard_continuous(cards::ADSL, by = "SEX", variables = "AGE")
+  attr(ard_mismatch, "args")$by <- "ARM"
+
+  # This will trigger the mismatch warning but successfully use "SEX" for processing
+  expect_snapshot(
+    res_mismatch <- shuffle_card(ard_mismatch, by = "SEX")
+  )
+  # Verify "SEX" was used as the column name instead of "ARM"
+  expect_true("SEX" %in% names(res_mismatch))
+  expect_false("ARM" %in% names(res_mismatch))
+
+  # 2. Match: Standard card where supplied matches attribute
+  ard_match <- cards::ard_continuous(cards::ADSL, by = "ARM", variables = "AGE")
+  expect_silent(
+    res_match <- shuffle_card(ard_match, by = "ARM")
+  )
+  expect_true("ARM" %in% names(res_match))
+
+  # 3. NULL supplied: Should remain silent and fall back to the attribute ("ARM")
+  expect_silent(
+    res_null <- shuffle_card(ard_match, by = NULL)
+  )
+  expect_true("ARM" %in% names(res_null))
+})

--- a/tests/testthat/test-utils_cards.R
+++ b/tests/testthat/test-utils_cards.R
@@ -1,0 +1,103 @@
+test_that("is_card works correctly", {
+  # Setup mock objects
+  good_card <- structure(list(), class = "card")
+  bad_card <- list()
+
+  expect_true(is_card(good_card))
+  expect_false(is_card(bad_card))
+})
+
+test_that("is_bind_ard_card works correctly", {
+  good_bind <- structure(list(), class = "bind_ard")
+  bad_bind <- structure(list(), class = "card")
+
+  expect_true(is_bind_ard_card(good_bind))
+  expect_false(is_bind_ard_card(bad_bind))
+})
+
+test_that("check_card passes valid inputs and handles allow_null", {
+  valid_card <- structure(list(), class = "card")
+
+  # Valid card should pass invisibly
+  expect_invisible(check_card(valid_card))
+  expect_null(check_card(valid_card))
+
+  # NULL should fail by default
+  expect_error(check_card(NULL), regexp = "`NULL` must be a card object, not `NULL`")
+
+  # NULL should pass when allow_null = TRUE
+  expect_invisible(check_card(NULL, allow_null = TRUE))
+  expect_null(check_card(NULL, allow_null = TRUE))
+})
+
+test_that("check_card throws correct rlang errors for invalid inputs", {
+  invalid_input <- "not a card"
+
+  # Test standard error throwing and message formatting
+  expect_error(
+    check_card(invalid_input, arg = "my_arg"),
+    regexp = "`my_arg` must be a card object"
+  )
+
+  # Missing argument should also fall through to stop_input_type
+  expect_error(
+    check_card(),
+    regexp ='argument "expr" is missing'
+  )
+})
+
+test_that("get_card_attr_arg extracts attributes properly", {
+  mock_card <- structure(
+    data.frame(),
+    class = "card",
+    args = list(by = "group_var", strata = "age_strata")
+  )
+
+  # Default "by" argument
+  expect_equal(get_card_attr_arg(mock_card), "group_var")
+
+  # Custom argument extraction
+  expect_equal(get_card_attr_arg(mock_card, arg = "strata"), "age_strata")
+
+  # Non-existent argument returns NULL
+  expect_null(get_card_attr_arg(mock_card, arg = "missing_arg"))
+})
+
+test_that("set_card_args modifies parameters properly", {
+  mock_card <- structure(data.frame(), class = "card", args = list(by = "old"))
+
+  # Modify an existing attribute element
+  modified_card <- set_card_args(mock_card, "by", "new")
+  expect_equal(attr(modified_card, "args")$by, "new")
+
+  # Add a new attribute element
+  modified_card <- set_card_args(modified_card, "variable", "var_name")
+  expect_equal(attr(modified_card, "args")$variable, "var_name")
+})
+
+test_that("drop_bind_ard_args clears stale args on bind_ard objects", {
+  # Case 1: Object is a bind_ard and has args attribute -> should drop targeted keys
+  mock_bind_ard <- structure(
+    data.frame(),
+    class = "bind_ard",
+    args = list(by = "sex", variable = "bmi", strata = "site", leave_me = "keep")
+  )
+
+  cleaned <- drop_bind_ard_args(mock_bind_ard)
+  expect_null(attr(cleaned, "args")$by)
+  expect_null(attr(cleaned, "args")$variable)
+  expect_null(attr(cleaned, "args")$strata)
+  expect_equal(attr(cleaned, "args")$leave_me, "keep")
+
+  # Case 2: Object is a bind_ard but has NO args attribute -> should do nothing without crashing
+  mock_no_args <- structure(data.frame(), class = "bind_ard")
+  expect_equal(drop_bind_ard_args(mock_no_args), mock_no_args)
+
+  # Case 3: Object is NOT a bind_ard -> should leave args untouched
+  mock_regular_card <- structure(
+    data.frame(),
+    class = "card",
+    args = list(by = "sex", variable = "bmi")
+  )
+  expect_equal(drop_bind_ard_args(mock_regular_card), mock_regular_card)
+})

--- a/vignettes/cards_to_tfrmt.Rmd
+++ b/vignettes/cards_to_tfrmt.Rmd
@@ -48,7 +48,7 @@ The first step in preparing the data for {tfrmt} is calling `shuffle_card()` whi
 
 ```{r}
 ard_demog_shuffled <- ard_demog |>
-  shuffle_card()
+  shuffle_card(by = "ARM")
 
 ard_demog_shuffled
 ```


### PR DESCRIPTION
…bind_ard

resolves #651 
I've updated to add a cli abort message if the attributes has class bind_ard and there is no by variable supplied then we have a message to tell the user to supply the by variables


issue related to this: https://github.com/GSK-Biostatistics/tfrmt/issues/640

so currently ive done the following:
basically the options are:

if class bind_ard then drop attributes, message user if they have not supplied a by

but i could update to do this:
 use attributes of the input and message user what it's inferring for by 
