### PR TITLE
make the message more helpful

### DIFF
--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -60,12 +60,22 @@ shuffle_card <- function(x,
     )
   }
 
-  # Check if a 'by' variable is available
+
+  # Check if a 'by' variable is available for bind_ard objs
+  by_arg <- get_card_attr_arg(x, "by")
   if (is_bind_ard_card(x) && rlang::is_empty(by)) {
+
+    by_msg <- if (!rlang::is_empty(by_arg)) {
+      c("*" = "A {.arg by} value of {.val {by_arg}} was found in the input object's attributes.",
+        "*" = "To use it as a grouping variable, pass it explicitly: {.code shuffle_card(by = \"{by_arg}\")}.")
+    } else {
+      c("*" = "If you want to use a grouping variable, pass it explicitly via the {.arg by} argument.")
+    }
+
     cli::cli_inform(
       c(
-        "The {.arg by} argument was not supplied and cannot be inferred from objects of class {.cls bind_ard}.",
-        "*" = "If you want to use a grouping variable, you'll need to pass it explicitly, e.g., {.code shuffle_card(by = 'TRT01A')}."
+        "The {.arg by} argument was not supplied and cannot reliably be inferred from objects of class {.cls bind_ard}.",
+        by_msg
       )
     )
   }
@@ -194,7 +204,7 @@ shuffle_card <- function(x,
 #' @noRd
 .process_by <- function(x, by) {
   by_arg <- get_card_attr_arg(x, "by")
-
+  
   # 1. If 'by' is explicitly supplied, it takes absolute priority
   if (!is.null(by)) {
     # Only inform if an attribute actually exists AND it doesn't match

--- a/tests/testthat/_snaps/shuffle_card.md
+++ b/tests/testthat/_snaps/shuffle_card.md
@@ -117,8 +117,9 @@
         "mean")), dplyr::tibble(group1 = "ARM", variable = "AGE", stat_name = "p",
         stat_label = "p", stat = list(0.05))), dplyr::row_number() <= 5L))
     Message
-      The `by` argument was not supplied and cannot be inferred from objects of class <bind_ard>.
-      * If you want to use a grouping variable, you'll need to pass it explicitly, e.g., `shuffle_card(by = 'TRT01A')`.
+      The `by` argument was not supplied and cannot reliably be inferred from objects of class <bind_ard>.
+      * A `by` value of "ARM" was found in the input object's attributes.
+      * To use it as a grouping variable, pass it explicitly: `shuffle_card(by = "ARM")`.
     Output
       # A tibble: 4 x 7
         ARM                  AGE      context stat_variable stat_name stat_label  stat
@@ -280,4 +281,13 @@
     Message
       i "Overall TRTA" already exists in the `TRTA` column. Using "Overall TRTA.1".
       i "Any AESOC" already exists in the `AESOC` column. Using"Any AESOC.1".
+
+# shuffle_card() preserves the attributes of a `card` object
+
+    Code
+      shuffled_ard <- shuffle_card(ard)
+    Message
+      The `by` argument was not supplied and cannot reliably be inferred from objects of class <bind_ard>.
+      * A `by` value of "ARM" was found in the input object's attributes.
+      * To use it as a grouping variable, pass it explicitly: `shuffle_card(by = "ARM")`.
 

--- a/tests/testthat/_snaps/shuffle_card.md
+++ b/tests/testthat/_snaps/shuffle_card.md
@@ -291,3 +291,30 @@
       * A `by` value of "ARM" was found in the input object's attributes.
       * To use it as a grouping variable, pass it explicitly: `shuffle_card(by = "ARM")`.
 
+---
+
+    Code
+      shuffle_card(ard_no_by_attr)
+    Message
+      The `by` argument was not supplied and cannot reliably be inferred from objects of class <bind_ard>.
+      * If you want to use a grouping variable, pass it explicitly via the `by` argument.
+    Output
+      # A tibble: 15 x 7
+         AGEGR1 SEX   context  stat_variable stat_name stat_label    stat
+         <chr>  <chr> <chr>    <chr>         <chr>     <chr>        <dbl>
+       1 65-80  <NA>  tabulate AGEGR1        n         n          144    
+       2 65-80  <NA>  tabulate AGEGR1        N         N          254    
+       3 65-80  <NA>  tabulate AGEGR1        p         %            0.567
+       4 <65    <NA>  tabulate AGEGR1        n         n           33    
+       5 <65    <NA>  tabulate AGEGR1        N         N          254    
+       6 <65    <NA>  tabulate AGEGR1        p         %            0.130
+       7 >80    <NA>  tabulate AGEGR1        n         n           77    
+       8 >80    <NA>  tabulate AGEGR1        N         N          254    
+       9 >80    <NA>  tabulate AGEGR1        p         %            0.303
+      10 <NA>   F     tabulate SEX           n         n          143    
+      11 <NA>   F     tabulate SEX           N         N          254    
+      12 <NA>   F     tabulate SEX           p         %            0.563
+      13 <NA>   M     tabulate SEX           n         n          111    
+      14 <NA>   M     tabulate SEX           N         N          254    
+      15 <NA>   M     tabulate SEX           p         %            0.437
+

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -558,8 +558,22 @@ test_that("shuffle_card() preserves the attributes of a `card` object", {
     attributes(ard)[["args"]],
     attributes(shuffled_ard)[["args"]]
   )
-})
 
+  # ard_stack uses bind_ard under the hood - attributes will be lost
+  ard <- cards::ard_stack(
+    data = adsl,
+    cards::ard_tabulate(variables = "AGEGR1"),
+    cards::ard_summary(variables = "AGE"),
+    .by = "ARM"
+  )
+
+  expect_snapshot(
+    shuffled_ard <- shuffle_card(ard)
+  )
+
+     
+})
+ 
 
 test_that("shuffle_card() sorting option", {
   withr::local_seed(0829)

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -571,9 +571,18 @@ test_that("shuffle_card() preserves the attributes of a `card` object", {
     shuffled_ard <- shuffle_card(ard)
   )
 
-     
+  # Binding two ARDs together class without a by attribute
+  ard_no_by_attr <- cards::bind_ard(
+    cards::ard_tabulate(cards::ADSL, variables = "AGEGR1"),
+    cards::ard_tabulate(cards::ADSL, variables = "SEX")
+  )
+
+  expect_snapshot(
+    shuffle_card(ard_no_by_attr)
+  )
+
 })
- 
+
 
 test_that("shuffle_card() sorting option", {
   withr::local_seed(0829)


### PR DESCRIPTION
Because `ard_stack` uses `bind_ard` under the hood, we are now dropping its attributes and not using them for shuffle_card (an oversight in the cards update). This is a regression, since we used to preserve the attributes of `ard_stack` and `by` was not required in `shuffle_card`. Adding a more explicit message and suggestion to the user to assist in updating their code to match previous behavior.

Note that `ard_stack_hierarchical` is not impacted.