### PR TITLE
Add check_input() for required tfrmt variables with cli messages

### DIFF
--- a/R/print_to_gt.R
+++ b/R/print_to_gt.R
@@ -143,6 +143,7 @@ print_to_gt <- function(tfrmt, .data, .unicode_ws = TRUE){
   if(!is.data.frame(.data)){
     stop("Requires data, if not available please use `print_mock_gt()`")
   }
+
   apply_tfrmt(.data, tfrmt, mock = FALSE) %>%
     cleaned_data_to_gt(tfrmt, .unicode_ws)
 

--- a/R/print_to_gt.R
+++ b/R/print_to_gt.R
@@ -143,7 +143,6 @@ print_to_gt <- function(tfrmt, .data, .unicode_ws = TRUE){
   if(!is.data.frame(.data)){
     stop("Requires data, if not available please use `print_mock_gt()`")
   }
-
   apply_tfrmt(.data, tfrmt, mock = FALSE) %>%
     cleaned_data_to_gt(tfrmt, .unicode_ws)
 

--- a/R/tfrmt.R
+++ b/R/tfrmt.R
@@ -208,6 +208,12 @@ tfrmt <- function(
   # check non-null big_n is supplied a big_n_structure
   check_big_n(new_tfrmt)
 
+  # check required input variables are supplied
+  check_input(new_tfrmt, "label")
+  check_input(new_tfrmt, "column")
+  check_input(new_tfrmt, "param")
+  check_input(new_tfrmt, "value")
+
 
   if(!missing(tfrmt_obj)){
     new_tfrmt <- layer_tfrmt(

--- a/R/tfrmt_checks.R
+++ b/R/tfrmt_checks.R
@@ -312,3 +312,27 @@ check_big_n <- function(tfrmt_object, parent_env = caller_env()) {
 }
 
 
+#' Check that a required tfrmt input variable is supplied
+#'
+#' @param tfrmt_object tfrmt object to check
+#' @param var_name name of the variable to check (e.g. "param", "label")
+#'
+#' @noRd
+#' @importFrom rlang quo_is_missing is_empty
+check_input <- function(tfrmt_object, var_name) {
+
+  var_val <- tfrmt_object[[var_name]]
+
+  is_missing <- if (var_name == "column") {
+    is_empty(var_val)
+  } else {
+    quo_is_missing(var_val)
+  }
+
+  if (is_missing) {
+    cli::cli_inform(
+      c("!" = "No value was supplied to {.arg {var_name}} in {.fun tfrmt}. Please supply a {.arg {var_name}} column.")
+    )
+  }
+}
+

--- a/R/tfrmt_checks.R
+++ b/R/tfrmt_checks.R
@@ -316,13 +316,15 @@ check_big_n <- function(tfrmt_object, parent_env = caller_env()) {
 #'
 #' @param tfrmt_object tfrmt object to check
 #' @param var_name name of the variable to check (e.g. "param", "label")
+#' @param parent_env parent environment for error reporting
 #'
 #' @noRd
-#' @importFrom rlang quo_is_missing is_empty
-check_input <- function(tfrmt_object, var_name) {
-
+#' @importFrom rlang quo_is_missing is_empty caller_env abort
+check_input <- function(tfrmt_object, var_name, parent_env = caller_env()) {
+  # extract the variable from the tfrmt_object
   var_val <- tfrmt_object[[var_name]]
 
+  # check if the user supplied a value to the variable
   is_missing <- if (var_name == "column") {
     is_empty(var_val)
   } else {
@@ -330,6 +332,7 @@ check_input <- function(tfrmt_object, var_name) {
   }
 
   if (is_missing) {
+    # display message
     cli::cli_inform(
       c("!" = "No value was supplied to {.arg {var_name}} in {.fun tfrmt}. Please supply a {.arg {var_name}} column.")
     )

--- a/tests/testthat/test-print_to_gt.R
+++ b/tests/testthat/test-print_to_gt.R
@@ -194,6 +194,76 @@ test_that("print_mock_gt() messages when tfrmt$param is missing", {
   )
 })
 
+test_that("tfrmt() messages when required variables are missing", {
+  expect_message(
+    tfrmt(
+      group = rowlbl1,
+      label = rowlbl2,
+      column = column,
+      value = value,
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt("")
+        )
+      )
+    ),
+    "No value was supplied to.*param"
+  )
+
+  expect_message(
+    tfrmt(
+      group = rowlbl1,
+      label = rowlbl2,
+      param = param,
+      value = value,
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt("")
+        )
+      )
+    ),
+    "No value was supplied to.*column"
+  )
+
+  expect_message(
+    tfrmt(
+      group = rowlbl1,
+      label = rowlbl2,
+      column = column,
+      param = param,
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt("")
+        )
+      )
+    ),
+    "No value was supplied to.*value"
+  )
+
+  expect_message(
+    tfrmt(
+      group = rowlbl1,
+      column = column,
+      param = param,
+      value = value,
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt("")
+        )
+      )
+    ),
+    "No value was supplied to.*label"
+  )
+})
+
 test_that("print_mock_gt() messages when tfrmt$column is missing", {
   # no message when tfrmt$column is not missing
   tfrmt_plan <- tfrmt(


### PR DESCRIPTION
Add check_input() helper that validates a single required tfrmt input variable, following the same pattern as check_plan(). Called individually for each required variable in tfrmt():

  check_input(new_tfrmt, 'label')
  check_input(new_tfrmt, 'column')
  check_input(new_tfrmt, 'param')
  check_input(new_tfrmt, 'value')

When a variable is missing, emits:

  ! No value was supplied to \param\ in \	frmt()\. Please supply a
    \param\ column.