### PR TITLE
increase test coverage for `apply_footnote_meta`

### DIFF
--- a/tests/testthat/test-apply_footnote_meta.R
+++ b/tests/testthat/test-apply_footnote_meta.R
@@ -223,47 +223,47 @@ test_that("applying footnote meta column val", {
     )
     # column val that doesn't exist in the data
     tfrmt4 <- tfrmt(
-      # specify columns in the data
-      group = c(rowlbl1),
-      label = rowlbl2,
-      column = trt,
-      param = param,
-      value = value,
-      # set formatting for value
-      body_plan = body_plan(
-        frmt_structure(
-          group_val = ".default",
-          label_val = ".default",
-          frmt_combine(
-            "{n} {pct}",
-            n = frmt("xxx"),
-            pct = frmt_when(
-              "==100" ~ "",
-              "==0" ~ "",
-              TRUE ~ frmt("(xx.x %)")
+        # specify columns in the data
+        group = c(rowlbl1),
+        label = rowlbl2,
+        column = trt,
+        param = param,
+        value = value,
+        # set formatting for value
+        body_plan = body_plan(
+            frmt_structure(
+                group_val = ".default",
+                label_val = ".default",
+                frmt_combine(
+                    "{n} {pct}",
+                    n = frmt("xxx"),
+                    pct = frmt_when(
+                        "==100" ~ "",
+                        "==0" ~ "",
+                        TRUE ~ frmt("(xx.x %)")
+                    )
+                )
             )
-          )
-        )
-      ),
-      footnote_plan = footnote_plan(
-        footnote_structure(
-          "Test footnote 1",
-          column_val = list(trt = "Not A Column")
         ),
-        marks = "letters"
-      )
+        footnote_plan = footnote_plan(
+            footnote_structure(
+                "Test footnote 1",
+                column_val = list(trt = "Not A Column")
+            ),
+            marks = "letters"
+        )
     )
     expect_message(
-      apply_tfrmt(es_data, tfrmt4),
-      "The provided column location does not exist in the provided data for the footnote"
+        apply_tfrmt(es_data, tfrmt4),
+        "The provided column location does not exist in the provided data for the footnote"
     )
     expect_equal(
-      attr(suppressMessages(apply_tfrmt(es_data, tfrmt4)), ".footnote_locs"),
-      list(list(
-        "col" = NULL,
-        "spanning" = FALSE,
-        "note" = "Test footnote 1"
-      ))
+        attr(suppressMessages(apply_tfrmt(es_data, tfrmt4)), ".footnote_locs"),
+        list(list(
+            "col" = NULL,
+            "spanning" = FALSE,
+            "note" = "Test footnote 1"
+        ))
     )
 })
 
@@ -606,49 +606,49 @@ test_that("applying footnote meta group val", {
 
     # row_grp_loc = "column" with a non-highest group referenced
     tfrmt7 <- tfrmt(
-      # specify columns in the data
-      group = c(rowlbl0, rowlbl1),
-      label = rowlbl2,
-      column = trt,
-      param = param,
-      value = value,
-      # set formatting for value
-      body_plan = body_plan(
-        frmt_structure(
-          group_val = ".default",
-          label_val = ".default",
-          frmt_combine(
-            "{n} {pct}",
-            n = frmt("xxx"),
-            pct = frmt_when(
-              "==100" ~ "",
-              "==0" ~ "",
-              TRUE ~ frmt("(xx.x %)")
+        # specify columns in the data
+        group = c(rowlbl0, rowlbl1),
+        label = rowlbl2,
+        column = trt,
+        param = param,
+        value = value,
+        # set formatting for value
+        body_plan = body_plan(
+            frmt_structure(
+                group_val = ".default",
+                label_val = ".default",
+                frmt_combine(
+                    "{n} {pct}",
+                    n = frmt("xxx"),
+                    pct = frmt_when(
+                        "==100" ~ "",
+                        "==0" ~ "",
+                        TRUE ~ frmt("(xx.x %)")
+                    )
+                )
             )
-          )
-        )
-      ),
-      # Locate the row group label in its own column, and only reference
-      # the second (non-highest) group in the footnote's group_val
-      row_grp_plan = row_grp_plan(
-        label_loc = element_row_grp_loc(location = "column")
-      ),
-      footnote_plan = footnote_plan(
-        footnote_structure(
-          "Test footnote",
-          group_val = list(rowlbl1 = "Completion Status")
         ),
-        marks = "letters"
-      )
+        # Locate the row group label in its own column, and only reference
+        # the second (non-highest) group in the footnote's group_val
+        row_grp_plan = row_grp_plan(
+            label_loc = element_row_grp_loc(location = "column")
+        ),
+        footnote_plan = footnote_plan(
+            footnote_structure(
+                "Test footnote",
+                group_val = list(rowlbl1 = "Completion Status")
+            ),
+            marks = "letters"
+        )
     )
     expect_equal(
-      attr(apply_tfrmt(es_data3, tfrmt7), ".footnote_locs"),
-      list(list(
-        "col" = "rowlbl1",
-        "spanning" = FALSE,
-        "row" = 1:3,
-        "note" = "Test footnote"
-      ))
+        attr(apply_tfrmt(es_data3, tfrmt7), ".footnote_locs"),
+        list(list(
+            "col" = "rowlbl1",
+            "spanning" = FALSE,
+            "row" = 1:3,
+            "note" = "Test footnote"
+        ))
     )
 })
 
@@ -772,4 +772,3 @@ test_that("If 1 group/column var, can pass an unnamed vector", {
         ))
     )
 })
-

--- a/tests/testthat/test-apply_footnote_meta.R
+++ b/tests/testthat/test-apply_footnote_meta.R
@@ -221,6 +221,50 @@ test_that("applying footnote meta column val", {
             )
         )
     )
+    # column val that doesn't exist in the data
+    tfrmt4 <- tfrmt(
+      # specify columns in the data
+      group = c(rowlbl1),
+      label = rowlbl2,
+      column = trt,
+      param = param,
+      value = value,
+      # set formatting for value
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt_combine(
+            "{n} {pct}",
+            n = frmt("xxx"),
+            pct = frmt_when(
+              "==100" ~ "",
+              "==0" ~ "",
+              TRUE ~ frmt("(xx.x %)")
+            )
+          )
+        )
+      ),
+      footnote_plan = footnote_plan(
+        footnote_structure(
+          "Test footnote 1",
+          column_val = list(trt = "Not A Column")
+        ),
+        marks = "letters"
+      )
+    )
+    expect_message(
+      apply_tfrmt(es_data, tfrmt4),
+      "The provided column location does not exist in the provided data for the footnote"
+    )
+    expect_equal(
+      attr(suppressMessages(apply_tfrmt(es_data, tfrmt4)), ".footnote_locs"),
+      list(list(
+        "col" = NULL,
+        "spanning" = FALSE,
+        "note" = "Test footnote 1"
+      ))
+    )
 })
 
 
@@ -559,6 +603,53 @@ test_that("applying footnote meta group val", {
         attr(apply_tfrmt(es_data3, tfrmt6), ".footnote_locs"),
         list(list("col" = NULL, "spanning" = FALSE, "note" = "Test footnote"))
     )
+
+    # row_grp_loc = "column" with a non-highest group referenced
+    tfrmt7 <- tfrmt(
+      # specify columns in the data
+      group = c(rowlbl0, rowlbl1),
+      label = rowlbl2,
+      column = trt,
+      param = param,
+      value = value,
+      # set formatting for value
+      body_plan = body_plan(
+        frmt_structure(
+          group_val = ".default",
+          label_val = ".default",
+          frmt_combine(
+            "{n} {pct}",
+            n = frmt("xxx"),
+            pct = frmt_when(
+              "==100" ~ "",
+              "==0" ~ "",
+              TRUE ~ frmt("(xx.x %)")
+            )
+          )
+        )
+      ),
+      # Locate the row group label in its own column, and only reference
+      # the second (non-highest) group in the footnote's group_val
+      row_grp_plan = row_grp_plan(
+        label_loc = element_row_grp_loc(location = "column")
+      ),
+      footnote_plan = footnote_plan(
+        footnote_structure(
+          "Test footnote",
+          group_val = list(rowlbl1 = "Completion Status")
+        ),
+        marks = "letters"
+      )
+    )
+    expect_equal(
+      attr(apply_tfrmt(es_data3, tfrmt7), ".footnote_locs"),
+      list(list(
+        "col" = "rowlbl1",
+        "spanning" = FALSE,
+        "row" = 1:3,
+        "note" = "Test footnote"
+      ))
+    )
 })
 
 
@@ -681,3 +772,4 @@ test_that("If 1 group/column var, can pass an unnamed vector", {
         ))
     )
 })
+


### PR DESCRIPTION
resolves #597 

Adds two new test cases covering previously untested edge cases in footnote location logic:

1. A footnote whose column location doesn't match any data in the table (should warn and skip gracefully instead of erroring).

2. A footnote whose row group location is set to `"column"` but only references a nested (non-top-level) group.