### PR TITLE
enable `missing_argument_linter`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -9,7 +9,6 @@ linters: all_linters(
   cyclocomp_linter(25),
   todo_comment_linter = NULL,
   function_argument_linter = NULL,
-  missing_argument_linter = NULL,
   implicit_integer_linter = NULL,
   unnecessary_lambda_linter = NULL,
   paste_linter = NULL,

--- a/.lintr_restrictive
+++ b/.lintr_restrictive
@@ -9,7 +9,6 @@ linters: all_linters(
   cyclocomp_linter(25),
   todo_comment_linter = NULL,
   function_argument_linter = NULL,
-  missing_argument_linter = NULL,
   implicit_integer_linter = NULL,
   unnecessary_lambda_linter = NULL,
   paste_linter = NULL,


### PR DESCRIPTION
resolves #766 