### PR TITLE
enable `expect_identical_linter`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -25,8 +25,6 @@ linters: all_linters(
   # conditions handling linters
   condition_call_linter = NULL,
   condition_message_linter = NULL,
-  # expectations linters
-  expect_identical_linter = NULL,
   # negation linters
   unnecessary_concatenation_linter = NULL,
   unnecessary_nesting_linter = NULL,

--- a/.lintr_restrictive
+++ b/.lintr_restrictive
@@ -25,8 +25,6 @@ linters: all_linters(
   # conditions handling linters
   condition_call_linter = NULL,
   condition_message_linter = NULL,
-  # expectations linters
-  expect_identical_linter = NULL,
   # negation linters
   unnecessary_concatenation_linter = NULL,
   unnecessary_nesting_linter = NULL,

--- a/tests/testthat/test-JSON.R
+++ b/tests/testthat/test-JSON.R
@@ -8,7 +8,7 @@ test_that("json basic tfrmt", {
     tfrmt() %>%
         as_json() %>%
         json_to_tfrmt(json = .) %>%
-        expect_equal(tfrmt())
+        expect_identical(tfrmt())
 
     #Complete tfrmt
     basic_filled_in <- tfrmt(
@@ -171,7 +171,7 @@ test_that("json body plan", {
     # Get out the function to see if it runs the same
     fx1 <- frmt4[[6]][[1]][[4]][[1]][[4]]
     fx2 <- new_frmt[[6]][[1]][[4]][[1]][[4]]
-    expect_equal(fx1(1:5), fx2(1:5))
+    expect_identical(fx1(1:5), fx2(1:5))
 
     #Format when test
     frmt_when_simp <- tfrmt(
@@ -383,7 +383,7 @@ test_that("json footnote plan", {
     gl_fn %>%
         as_json() %>%
         json_to_tfrmt(json = .) %>%
-        expect_equal(gl_fn)
+        expect_identical(gl_fn)
 
     # Nest columns
     nested_fn <- tfrmt(

--- a/tests/testthat/test-apply_footnote_meta.R
+++ b/tests/testthat/test-apply_footnote_meta.R
@@ -59,7 +59,7 @@ test_that("applying footnote meta column val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data, tfrmt), ".footnote_locs"),
         list(list(
             "col" = "Placebo",
@@ -100,7 +100,7 @@ test_that("applying footnote meta column val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data, tfrmt2), ".footnote_locs"),
         list(list(
             "col" = "Placebo",
@@ -155,7 +155,7 @@ test_that("applying footnote meta column val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data2, tfrmt3), ".footnote_locs"),
         list(list(
             "col" = "Treatment column",
@@ -211,7 +211,7 @@ test_that("applying footnote meta column val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data2, tfrmt3), ".footnote_locs"),
         list(
             list(
@@ -257,7 +257,7 @@ test_that("applying footnote meta column val", {
         apply_tfrmt(es_data, tfrmt4),
         "The provided column location does not exist in the provided data for the footnote"
     )
-    expect_equal(
+    expect_identical(
         attr(suppressMessages(apply_tfrmt(es_data, tfrmt4)), ".footnote_locs"),
         list(list(
             "col" = NULL,
@@ -444,12 +444,12 @@ test_that("applying footnote meta group val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data2, tfrmt3), ".footnote_locs"),
         list(list(
             "col" = "rowlbl1",
             "spanning" = FALSE,
-            "row" = 1,
+            "row" = 1L,
             "note" = "Test footnote"
         ))
     )
@@ -497,12 +497,12 @@ test_that("applying footnote meta group val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data2, tfrmt4), ".footnote_locs"),
         list(list(
             "col" = "rowlbl2",
             "spanning" = FALSE,
-            "row" = 1,
+            "row" = 1L,
             "note" = "Test footnote"
         ))
     )
@@ -556,12 +556,12 @@ test_that("applying footnote meta group val", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data3, tfrmt5), ".footnote_locs"),
         list(list(
             "col" = "rowlbl1",
             "spanning" = FALSE,
-            "row" = 1,
+            "row" = 1L,
             "note" = "Test footnote"
         ))
     )
@@ -599,7 +599,7 @@ test_that("applying footnote meta group val", {
             footnote_structure("Test footnote")
         )
     )
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data3, tfrmt6), ".footnote_locs"),
         list(list("col" = NULL, "spanning" = FALSE, "note" = "Test footnote"))
     )
@@ -641,7 +641,7 @@ test_that("applying footnote meta group val", {
             marks = "letters"
         )
     )
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(es_data3, tfrmt7), ".footnote_locs"),
         list(list(
             "col" = "rowlbl1",
@@ -713,7 +713,7 @@ test_that("If 1 group/column var, can pass an unnamed vector", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(dd, tfrmt), ".footnote_locs"),
         list(list(
             "col" = c("Trt1", "Trt2", "Trt3"),
@@ -762,12 +762,12 @@ test_that("If 1 group/column var, can pass an unnamed vector", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         attr(apply_tfrmt(dd, tfrmt), ".footnote_locs"),
         list(list(
             "col" = "rowlbl1",
             "spanning" = FALSE,
-            "row" = c(1, 2),
+            "row" = c(1L, 2L),
             note = "Test footnote 1"
         ))
     )

--- a/tests/testthat/test-apply_footnote_plan.R
+++ b/tests/testthat/test-apply_footnote_plan.R
@@ -103,7 +103,7 @@ test_that("applying footnote plan", {
 
     gt1 <- apply_footnote_plan(gt_start, tfrmt1, list())
 
-    expect_equal(nrow(gt1$`_footnotes`), 0)
+    expect_identical(nrow(gt1$`_footnotes`), 0L)
 
     # source footnote #################################################################
 
@@ -152,7 +152,7 @@ test_that("applying footnote plan", {
         list(list(col = NULL, spanning = FALSE, note = "Source Note"))
     )
 
-    expect_equal(gt2$`_footnotes`$footnotes, list("Source Note"))
+    expect_identical(gt2$`_footnotes`$footnotes, list("Source Note"))
 
     # column footnote ##################################################################
 
@@ -190,7 +190,7 @@ test_that("applying footnote plan", {
         tfrmt3,
         list(list(col = "Placebo", spanning = FALSE, note = "Test foontote 2"))
     )
-    expect_equal(nrow(gt3$`_footnotes`), 1)
+    expect_identical(nrow(gt3$`_footnotes`), 1L)
 
     # spanner footnote ##################################################################
 
@@ -284,7 +284,7 @@ test_that("applying footnote plan", {
             note = "Test foontote 3"
         ))
     )
-    expect_equal(nrow(gt4$`_footnotes`), 1)
+    expect_identical(nrow(gt4$`_footnotes`), 1L)
 
     # body footnote ##################################################################
 
@@ -332,7 +332,7 @@ test_that("applying footnote plan", {
             note = "Test foontote 2"
         ))
     )
-    expect_equal(nrow(gt5$`_footnotes`), 1)
+    expect_identical(nrow(gt5$`_footnotes`), 1L)
 
     # stub footnote ##################################################################
     tfrmt6 <- tfrmt(
@@ -384,7 +384,7 @@ test_that("applying footnote plan", {
             note = "Test foontote"
         ))
     )
-    expect_equal(nrow(gt6$`_footnotes`), 2)
+    expect_identical(nrow(gt6$`_footnotes`), 2L)
 
     # group footnote ##################################################################
 
@@ -440,7 +440,7 @@ test_that("applying footnote plan", {
             note = "Test foontote"
         ))
     )
-    expect_equal(nrow(gt7$`_footnotes`), 1)
+    expect_identical(nrow(gt7$`_footnotes`), 1L)
 })
 
 
@@ -480,7 +480,7 @@ test_that("Check footnote order option works as expected", {
     gt_out <- print_mock_gt(tfrmt_ord)
 
     current_order_opt <- gt_out[["_options"]][["value"]][[1]]
-    expect_equal(current_order_opt, "marks_first")
+    expect_identical(current_order_opt, "marks_first")
 
     #check the footnotes are all printed
     actual_fns <- gt_out$`_footnotes`$footnotes
@@ -492,7 +492,7 @@ test_that("Check footnote order option works as expected", {
         "label_1 footnote"
     )
 
-    expect_equal(as.character(actual_fns), expected_fns)
+    expect_identical(as.character(actual_fns), expected_fns)
 
     #check preserve_order
     tfrmt_ord <- tfrmt_ord |>
@@ -512,7 +512,7 @@ test_that("Check footnote order option works as expected", {
 
     gt_out <- print_mock_gt(tfrmt_ord)
     current_order_opt <- gt_out[["_options"]][["value"]][[1]]
-    expect_equal(current_order_opt, "preserve_order")
+    expect_identical(current_order_opt, "preserve_order")
 
     # check marks last
     tfrmt_ord <- tfrmt_ord |>
@@ -532,5 +532,5 @@ test_that("Check footnote order option works as expected", {
 
     gt_out <- print_mock_gt(tfrmt_ord)
     current_order_opt <- gt_out[["_options"]][["value"]][[1]]
-    expect_equal(current_order_opt, "marks_last")
+    expect_identical(current_order_opt, "marks_last")
 })

--- a/tests/testthat/test-apply_frmt.R
+++ b/tests/testthat/test-apply_frmt.R
@@ -25,17 +25,17 @@ test_that("applying frmt", {
         value = quo(x)
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_no_dec_frmted$x,
         c("1235", "346", " 57", "4568", "  9")
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_single_dec_frmted$x,
         c("1234.6", "345.7", " 56.8", "4567.9", "  8.9")
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_double_dec_frmted$x,
         c("1234.57", "345.68", " 56.79", "4567.89", "  8.91")
     )
@@ -75,7 +75,7 @@ test_that("applying frmt - scientific", {
         frmt_def = sample_frmt_exxxx
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_10x$x,
         c(
             "  1.2 x10^3",
@@ -87,7 +87,7 @@ test_that("applying frmt - scientific", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_10xx$x,
         c(
             "  1.2 x10^ 3",
@@ -99,7 +99,7 @@ test_that("applying frmt - scientific", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_ex$x,
         c(
             "  1.2e^3",
@@ -110,7 +110,7 @@ test_that("applying frmt - scientific", {
             "  6.8e^-2"
         )
     )
-    expect_equal(
+    expect_identical(
         sample_df_frmted_exxxx$x,
         c(
             "  1.2e^   3",
@@ -141,7 +141,7 @@ test_that("applying frmt - transform", {
     ) %>%
         pull(x)
 
-    expect_equal(
+    expect_identical(
         formula_result,
         c("123457", "34568", "5679", "456789", "891")
     )
@@ -153,7 +153,7 @@ test_that("applying frmt - transform", {
     ) %>%
         pull(x)
 
-    expect_equal(
+    expect_identical(
         fx_result,
         c("1524157.7", "119493.9", "3225.0", "20865628.2", " 79.4")
     )
@@ -187,17 +187,17 @@ test_that("applying frmt - preserves decimal places after rounding", {
         frmt_def = sample_frmt_10x
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_1dec$x,
         c(" 10.0", " 12.4", "  3.0", "100.0", "167.3")
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_2dec$x,
         c(" 10.00", " 12.36", "  3.00", "100.00", "167.30")
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted_10x$x,
         c(
             "  1.0 x10^1",
@@ -238,7 +238,7 @@ test_that("applying frmt_combine - 2x", {
         group = vars(group)
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             group = "group",
@@ -287,7 +287,7 @@ test_that("applying frmt_combine missing", {
         group = vars(group)
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             group = "group",
@@ -333,7 +333,7 @@ test_that("applying frmt_combine missing", {
         group = vars(group)
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             group = "group",
@@ -382,7 +382,7 @@ test_that("applying frmt_combine - 3x", {
         group = vars(group)
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             group = "group",
@@ -434,7 +434,7 @@ test_that("applying frmt_combine - no unique labels, so unable to frmt_combine",
         "Unable to apply `frmt_combine` due to uniqueness of column/row identifiers. Params that are to be combined need to have matching values across: "
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             group = "group",
@@ -525,7 +525,7 @@ test_that("applying frmt_when", {
     )
     # nolint end
 
-    expect_equal(sample_df_frmted, man_df)
+    expect_identical(sample_df_frmted, man_df)
 
     #Test in combination
     sample_frmt_combo <- frmt_combine(
@@ -557,7 +557,7 @@ test_that("applying frmt_when", {
         "group" , "lab 5" , "col" , "A" , "5678.9 (5.7%)"       ,
     )
     # nolint end
-    expect_equal(sample_df_frmted, man_df_combo)
+    expect_identical(sample_df_frmted, man_df_combo)
 })
 
 
@@ -570,7 +570,7 @@ test_that("mocks return correctly", {
         mock = TRUE
     ) %>%
         pull(mock)
-    expect_equal(frmt_mock, rep("xxx.x", nrow(iris)))
+    expect_identical(frmt_mock, rep("xxx.x", nrow(iris)))
 
     # frmt_when
     frmt_when_true <- apply_frmt.frmt_when(
@@ -580,7 +580,7 @@ test_that("mocks return correctly", {
         mock = TRUE
     ) %>%
         pull(value)
-    expect_equal(frmt_when_true, rep("(XXX.X%)", nrow(iris)))
+    expect_identical(frmt_when_true, rep("(XXX.X%)", nrow(iris)))
 
     frmt_when_no_true <- apply_frmt.frmt_when(
         frmt_when("==100" ~ frmt("Hello"), "==0" ~ ""),
@@ -589,7 +589,7 @@ test_that("mocks return correctly", {
         mock = TRUE
     ) %>%
         pull(value)
-    expect_equal(frmt_when_no_true, rep("Hello", nrow(iris)))
+    expect_identical(frmt_when_no_true, rep("Hello", nrow(iris)))
 
     #frmt_combine
     sample_df <- tibble(
@@ -618,7 +618,7 @@ test_that("mocks return correctly", {
     ) %>%
         pull(x)
 
-    expect_equal(sample_df_frmted, rep("xxx.x (X.X%)", 5))
+    expect_identical(sample_df_frmted, rep("xxx.x (X.X%)", 5))
 })
 
 
@@ -629,7 +629,7 @@ test_that("Space in Param", {
         `LM stderr` = frmt("xx.xx")
     )
 
-    expect_equal(no_ten$expression, "{`LM mean`} ({`LM stderr`})")
+    expect_identical(no_ten$expression, "{`LM mean`} ({`LM stderr`})")
 
     mixed <- frmt_combine(
         "{mean} ({CV %})",
@@ -637,7 +637,7 @@ test_that("Space in Param", {
         `CV %` = frmt("xx.xx")
     )
 
-    expect_equal(mixed$expression, "{mean} ({`CV %`})")
+    expect_identical(mixed$expression, "{mean} ({`CV %`})")
 
     # nolint start: commas_linter
     data <- tibble::tribble(
@@ -655,7 +655,7 @@ test_that("Space in Param", {
         `LM stderr` = frmt("xx.xx")
     )
 
-    expect_equal(space_combo$expression, "{`LM mean`} ({`LM stderr`})")
+    expect_identical(space_combo$expression, "{`LM mean`} ({`LM stderr`})")
 
     sample_df_frmted <- apply_frmt.frmt_combine(
         frmt_def = space_combo,
@@ -669,7 +669,7 @@ test_that("Space in Param", {
     ) %>%
         pull(value)
 
-    expect_equal(sample_df_frmted, c("79.0 ( 5.00)", "-0.3 ( 0.40)"))
+    expect_identical(sample_df_frmted, c("79.0 ( 5.00)", "-0.3 ( 0.40)"))
 })
 
 
@@ -713,7 +713,7 @@ test_that("frmt_combine only applies when all parameters are in the data", {
         filter(Label %in% c("Male", "Female")) %>%
         pull(TEMP_row)
 
-    expect_equal(rows_to_use, expected)
+    expect_identical(rows_to_use, expected)
 })
 
 test_that("frmt_combine fills with partially missing values where a column is missing the value", {
@@ -743,7 +743,7 @@ test_that("frmt_combine fills with partially missing values where a column is mi
         mock = FALSE
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             Group = rep(c("Age (y)"), c(3)),
@@ -771,7 +771,7 @@ test_that("frmt_combine fills with partially missing values where a column is mi
         mock = FALSE
     )
 
-    expect_equal(
+    expect_identical(
         sample_df_frmted,
         tibble(
             Group = rep(c("Age (y)"), c(3)),

--- a/tests/testthat/test-apply_page_plan.R
+++ b/tests/testthat/test-apply_page_plan.R
@@ -32,7 +32,7 @@ test_that("Page plan with defined split", {
         # nolint end
     )
 
-    expect_equal(auto_split, man_split)
+    expect_identical(auto_split, man_split)
 })
 
 
@@ -80,11 +80,11 @@ test_that("Page plan with grouped split", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("grp: A", "grp: B", "grp: C")
     )
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         "grp"
     )
@@ -129,12 +129,12 @@ test_that("Page plan with grouped split", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("grp2: a", "grp2: b")
     )
 
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         "grp2"
     )
@@ -181,7 +181,7 @@ test_that("Page plan with grouped split", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c(
             "grp1: A, grp2: a",
@@ -190,7 +190,7 @@ test_that("Page plan with grouped split", {
             "grp1: B, grp2: b"
         )
     )
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         c("grp1", "grp2")
     )
@@ -231,11 +231,11 @@ test_that("Page plan with grouped split", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("lbl: n", "lbl: pct")
     )
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         "lbl"
     )
@@ -344,11 +344,11 @@ test_that("page plan with mix of defined & group splits", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("grp1: A", "grp1: A", "grp1: B", "grp1: B")
     )
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         "grp1"
     )
@@ -425,11 +425,11 @@ test_that("page plan with multiple structures", {
         ignore_attr = c(".page_note", ".page_grp_vars")
     )
 
-    expect_equal(
+    expect_identical(
         map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("grp1: A", "grp1: A", "grp1: A", "grp1: B", "grp1: B", "grp1: B")
     )
-    expect_equal(
+    expect_identical(
         attr(auto_split, ".page_grp_vars"),
         "grp1"
     )
@@ -796,7 +796,7 @@ test_that("page plan with both page_structure and max_rows", {
         ignore_attr = TRUE
     )
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c(
             "grp1: cat_1",
@@ -872,7 +872,7 @@ test_that("page plan with page_structure, single level variable", {
 
     expect_equal(auto_split, man_split, ignore_attr = TRUE)
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("grp1: cat_1")
     )
@@ -924,7 +924,7 @@ test_that("page_plan() with transform", {
 
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("group 1: cat_1")
     )
@@ -938,7 +938,7 @@ test_that("page_plan() with transform", {
 
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c("group 1: category 1")
     )
@@ -988,7 +988,7 @@ test_that("page_plan() with transform and multiple 'page by' variables", {
     # without page label transformation
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c(
             "grp1: cat_1, grp2: cat_1",
@@ -1020,7 +1020,7 @@ test_that("page_plan() with transform and multiple 'page by' variables", {
 
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
-    expect_equal(
+    expect_identical(
         purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
         c(
             "Group 1 (cat_1), Group 2 (cat_1)",

--- a/tests/testthat/test-apply_row_grp_plan.R
+++ b/tests/testthat/test-apply_row_grp_plan.R
@@ -17,7 +17,7 @@ test_that("insert post space - single grouping variable", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -47,7 +47,7 @@ test_that("insert post space - single grouping variable", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -98,7 +98,7 @@ test_that("insert post space - two grouping variables", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -139,7 +139,7 @@ test_that("insert post space - two grouping variables", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -191,7 +191,7 @@ test_that("insert mix - single grouping variable", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(df, sample_grp_plan$struct_list, vars(grp1)) %>%
             select(-..tfrmt_post_space_row),
         # nolint start: commas_linter
@@ -227,7 +227,7 @@ test_that("insert post space after specific value", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -274,7 +274,7 @@ test_that("overlapping row_grp_structures - prefers latest", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(
             df,
             sample_grp_plan$struct_list,
@@ -319,7 +319,7 @@ test_that("no post space added if NULL", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(df, sample_grp_plan$struct_list, vars(grp1)),
         # nolint start: commas_linter
         tibble::tribble(
@@ -350,7 +350,7 @@ test_that("post space is truncated to data width", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(df, sample_grp_plan$struct_list, vars(grp1)) %>%
             select(-..tfrmt_post_space_row),
         # nolint start: commas_linter
@@ -386,7 +386,7 @@ test_that("do not recycle the post space for full width", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(df, sample_grp_plan$struct_list, vars(grp1)) %>%
             select(-..tfrmt_post_space_row),
         # nolint start: commas_linter
@@ -422,7 +422,7 @@ test_that("post space works when data contains NAs", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_struct(df, sample_grp_plan$struct_list, vars(grp1)) %>%
             select(-..tfrmt_post_space_row),
         # nolint start: commas_linter
@@ -469,9 +469,9 @@ test_that("Check combine_group_cols with a single group", {
     )
     # nolint end
 
-    expect_equal(auto_test_no_span, man_test_no_span)
+    expect_identical(auto_test_no_span, man_test_no_span)
     #With spanning (so no change to the data)
-    expect_equal(
+    expect_identical(
         combine_group_cols(
             mock_single_grp,
             group = vars(grp1),
@@ -533,7 +533,7 @@ test_that("Check combine_group_cols with a multi groups", {
     )
     # nolint end
 
-    expect_equal(auto_test_no_span, man_test_no_span)
+    expect_identical(auto_test_no_span, man_test_no_span)
 
     auto_test_with_span <- combine_group_cols(
         mock_multi_grp,
@@ -557,7 +557,7 @@ test_that("Check combine_group_cols with a multi groups", {
         mutate(grp1 = ifelse(grp1 == "", NA, grp1)) %>%
         fill(grp1, .direction = "up")
 
-    expect_equal(
+    expect_identical(
         auto_test_with_span,
         man_test_with_span
     )
@@ -629,7 +629,7 @@ test_that("Check apply_row_grp_* w/ list-columns (in case of incomplete body_pla
             dplyr::across(trtA:trtC, ~ as.list(.x))
         )
 
-    expect_equal(
+    expect_identical(
         auto_test_listcols,
         man_test_listcols
     )
@@ -666,7 +666,7 @@ test_that("Check apply_row_grp_* w/ list-columns (in case of incomplete body_pla
             )
         )
 
-    expect_equal(auto_test_listcols, man_test_listcols)
+    expect_identical(auto_test_listcols, man_test_listcols)
 })
 
 
@@ -692,7 +692,7 @@ test_that("> 2 groups with and without spanner_label", {
 
     plan_no_span <- row_grp_plan()
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             plan_no_span$label_loc,
@@ -731,7 +731,7 @@ test_that("> 2 groups with and without spanner_label", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             plan_with_span$label_loc,
@@ -785,7 +785,7 @@ test_that("Summary rows are not indented", {
 
     plan_no_span <- row_grp_plan()
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             plan_no_span$label_loc,
@@ -816,7 +816,7 @@ test_that("Summary rows are not indented", {
         label_loc = element_row_grp_loc(location = "spanning")
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             plan_with_span$label_loc,
@@ -850,7 +850,7 @@ test_that("Summary rows are not indented", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             plan_with_column$label_loc,
@@ -964,7 +964,7 @@ test_that("row order is retained for all selections", {
         "b"   , "  e" , "4"  , FALSE
     )
     # nolint end
-    expect_equal(gt_spanning_dat, gt_spanning_man)
+    expect_identical(gt_spanning_dat, gt_spanning_man)
 
     gt_column <- tfrmt_temp %>%
         tfrmt(
@@ -1135,7 +1135,7 @@ test_that("Row group plans with col style plan", {
         tfrmt_gt <- print_to_gt(plan, raw_dat)
     })
 
-    expect_equal(
+    expect_identical(
         tfrmt_gt$`_data` %>%
             select(-`..tfrmt_row_grp_lbl`) %>%
             as.list(),
@@ -1304,7 +1304,7 @@ test_that("Suppress printing of groups", {
     )
     # nolint end
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             mock_multi_grp,
             my_plan$label_loc,
@@ -1349,7 +1349,7 @@ test_that("Row group plan indenting handles factor variables", {
     )
     # nolint end
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             dat %>%
                 mutate(
@@ -1369,7 +1369,7 @@ test_that("Row group plan indenting handles factor variables", {
         expected
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             dat %>%
                 mutate(
@@ -1389,7 +1389,7 @@ test_that("Row group plan indenting handles factor variables", {
         expected
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             dat %>%
                 mutate(
@@ -1409,7 +1409,7 @@ test_that("Row group plan indenting handles factor variables", {
         expected
     )
 
-    expect_equal(
+    expect_identical(
         apply_row_grp_lbl(
             dat %>%
                 mutate(

--- a/tests/testthat/test-apply_tfrmt.R
+++ b/tests/testthat/test-apply_tfrmt.R
@@ -124,7 +124,7 @@ test_that("pivot_wider_tfrmt gives message when frmt_combine may be missing", {
     # use quietly to grab messages from apply_tfrmt
     safe_apply_tfrmt <- purrr::quietly(apply_tfrmt)
 
-    expect_equal(
+    expect_identical(
         safe_apply_tfrmt(
             data_demog %>% filter(rowlbl1 == "Age (y)"),
             tfrmt_temp2,
@@ -153,7 +153,7 @@ test_that("test tentative_process", {
     }
 
     ## function passing in tentative process
-    expect_equal(
+    expect_identical(
         tentative_process("x", passing_func),
         "xvalue"
     )
@@ -163,13 +163,13 @@ test_that("test tentative_process", {
     })
 
     expect_true(is_empty(passing_func_messages))
-    expect_equal(
+    expect_identical(
         passing_func_messages,
         character()
     )
 
     ## function failing in tentative process
-    expect_equal(
+    expect_identical(
         suppressMessages(tentative_process("x", failing_func)),
         "x"
     )
@@ -179,13 +179,13 @@ test_that("test tentative_process", {
     })
 
     expect_false(is_empty(failing_func_messages))
-    expect_equal(
+    expect_identical(
         failing_func_messages,
         "Unable to to apply failing_func.\nReason: this function failed\n"
     )
 
     ## function failing in tentative process
-    expect_equal(
+    expect_identical(
         suppressMessages(tentative_process("x", rlang_abort_func)),
         "x"
     )
@@ -195,7 +195,7 @@ test_that("test tentative_process", {
     })
 
     expect_false(is_empty(rlang_abort_func_messages))
-    expect_equal(
+    expect_identical(
         rlang_abort_func_messages,
         "Unable to to apply rlang_abort_func.\nReason: this function failed2\n"
     )
@@ -219,7 +219,7 @@ test_that("tentative_process handles errors with empty message", {
     expect_snapshot(
         result <- tentative_process("x", empty_msg_func)
     )
-    expect_equal(result, "x")
+    expect_identical(result, "x")
 })
 
 test_that("frmt_struct_string handles no group variables", {

--- a/tests/testthat/test-col_plan.R
+++ b/tests/testthat/test-col_plan.R
@@ -954,7 +954,7 @@ test_that("Order is kept for multi-col columns", {
         unite("new", sep = .tlang_delim) %>%
         pull(new)
 
-    expect_equal(new_name_ord, new_name_ord_in_dat)
+    expect_identical(new_name_ord, new_name_ord_in_dat)
 })
 
 test_that("Build simple tfrmt with multiple columns and apply to basic data and compare against spanning_structure", {
@@ -1010,7 +1010,7 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "group",
@@ -1023,12 +1023,12 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("span 1")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c("span 1___tlang_delim___col1", "span 1___tlang_delim___col2")
@@ -1085,7 +1085,7 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "new_col_4",
@@ -1098,12 +1098,12 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("span 1")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c("span 1___tlang_delim___new_col_1", "span 1___tlang_delim___col2")
@@ -1163,7 +1163,7 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "new_col_4",
@@ -1176,12 +1176,12 @@ test_that("Build simple tfrmt with multiple columns and apply to basic data and 
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("new span name")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c(
@@ -1251,7 +1251,7 @@ test_that("Build simple tfrmt with multiple columns and with renaming duplicated
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "label",
@@ -1268,17 +1268,17 @@ test_that("Build simple tfrmt with multiple columns and with renaming duplicated
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("A", "B", "C", "D", "A_", "B_")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_level,
-        c(1, 1, 1, 1, 2, 2)
+        c(1L, 1L, 1L, 1L, 2L, 2L)
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c(
@@ -1368,7 +1368,7 @@ test_that("Build simple tfrmt with spans with child spans that are and are not s
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "group",
@@ -1382,17 +1382,17 @@ test_that("Build simple tfrmt with spans with child spans that are and are not s
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("cols 1,2", "column cols", "my cols")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_level,
-        c(1, 2, 1)
+        c(1L, 2L, 1L)
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c(
@@ -1471,7 +1471,7 @@ test_that("Build simple tfrmt with spans with child spans that are and are not s
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c(
             "group",
@@ -1484,17 +1484,17 @@ test_that("Build simple tfrmt with spans with child spans that are and are not s
         )
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_label %>% map_chr(as.character),
         c("cols 1,2", "column cols", "my cols")
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$spanner_level,
-        c(1, 2, 1)
+        c(1L, 2L, 1L)
     )
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_spanners"]]$vars,
         list(
             c(
@@ -1752,11 +1752,11 @@ test_that("Build simple tfrmt with stub header", {
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c("label", "tst", "col3", "col1", "..tfrmt_row_grp_lbl")
     )
-    expect_equal(
+    expect_identical(
         processed_gt[["_stubhead"]]$label,
         md("grp")
     )
@@ -1805,11 +1805,11 @@ test_that("Build simple tfrmt with stub header", {
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c("label", "tst", "col3", "col1", "..tfrmt_row_grp_lbl")
     )
-    expect_equal(
+    expect_identical(
         processed_gt[["_stubhead"]]$label,
         md("")
     )
@@ -1866,11 +1866,11 @@ test_that("Build simple tfrmt with stub header", {
         )
     })
 
-    expect_equal(
+    expect_identical(
         processed_gt[["_boxhead"]]$column_label %>% map_chr(as.character),
         c("grp1", "grp2", "label", "tst", "col3", "col1", "..tfrmt_row_grp_lbl")
     )
-    expect_equal(
+    expect_identical(
         processed_gt[["_stubhead"]]$label,
         md(c("Group 1", "Group 2", "Row label"))
     )

--- a/tests/testthat/test-col_style_structure.R
+++ b/tests/testthat/test-col_style_structure.R
@@ -116,12 +116,12 @@ test_that("col_style_plan - error non-element_col", {
 test_that("left & right align works", {
     vec <- c(" xx.xxx", "xx", " x,  x")
 
-    expect_equal(
+    expect_identical(
         apply_col_alignment(vec, align = "left"),
         c(" xx.xxx", "xx     ", " x,  x ")
     )
 
-    expect_equal(
+    expect_identical(
         apply_col_alignment(vec, align = "right"),
         c(" xx.xxx", "     xx", "  x,  x")
     )
@@ -130,12 +130,12 @@ test_that("left & right align works", {
 test_that("decimal align works", {
     vec <- c(" xx.xx", " x, x", "xxx", " x (x.x)")
 
-    expect_equal(
+    expect_identical(
         apply_col_alignment(vec, align = c(".", " ")),
         c(" xx.xx   ", " x, x    ", "xxx      ", "  x (x.x)")
     )
 
-    expect_equal(
+    expect_identical(
         apply_col_alignment(vec, align = c(".", ",", " ")),
         c(" xx.xx   ", "  x, x   ", "xxx      ", "  x (x.x)")
     )
@@ -211,7 +211,7 @@ test_that("alignment of multiple columns works", {
         ) %>%
         apply_col_style_plan(tfrmt_obj)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man %>%
             pivot_wider(
@@ -264,7 +264,7 @@ test_that("alignment of multiple columns works", {
         ) %>%
         apply_col_style_plan(plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man %>%
             pivot_wider(
@@ -333,7 +333,7 @@ test_that("tidyselect works", {
         ) %>%
         apply_col_style_plan(starts_with_align_dot_plan)
 
-    expect_equal(dat_aligned, dat_aligned_man)
+    expect_identical(dat_aligned, dat_aligned_man)
 
     vars_starts_with_plan <- tfrmt(
         label = one,
@@ -367,7 +367,7 @@ test_that("tidyselect works", {
         ) %>%
         apply_col_style_plan(vars_starts_with_plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man
     )
@@ -391,7 +391,7 @@ test_that("tidyselect works", {
         ) %>%
         apply_col_style_plan(starts_with_plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man
     )
@@ -431,7 +431,7 @@ test_that("tidyselect works", {
             col_plan_vars = vars(one, trt1, trt2, four)
         )
 
-    expect_equal(dat_aligned, dat_aligned_man)
+    expect_identical(dat_aligned, dat_aligned_man)
 })
 
 test_that("span_structure works", {
@@ -495,7 +495,7 @@ test_that("span_structure works", {
         clean_spanning_col_names() %>%
         apply_col_style_plan(plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man
     )
@@ -644,7 +644,7 @@ test_that("Overlapping col_style_structure favors last one", {
         ) %>%
         apply_col_style_plan(plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man %>%
             pivot_wider(
@@ -728,7 +728,7 @@ test_that("Align strings >1 in length", {
         ) %>%
         apply_col_style_plan(plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man %>%
             pivot_wider(
@@ -812,7 +812,7 @@ test_that("Alphanumeric align string supplied", {
         ) %>%
         apply_col_style_plan(plan)
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man %>%
             pivot_wider(
@@ -832,7 +832,7 @@ test_that("multi-positional alignment", {
         type = "pos"
     )
 
-    expect_equal(
+    expect_identical(
         vec_aligned,
         c(
             "xx.x (xx.x)   ",
@@ -850,7 +850,7 @@ test_that("multi-positional alignment", {
         type = "pos"
     )
 
-    expect_equal(
+    expect_identical(
         vec_aligned,
         c(
             "xx.x          ",
@@ -869,7 +869,7 @@ test_that("multi-positional alignment", {
             type = "pos"
         )
     })
-    expect_equal(
+    expect_identical(
         vec_aligned,
         c(
             "          xx.x         ",
@@ -918,7 +918,7 @@ test_that("multi-positional alignment", {
     )
     # nolint end
 
-    expect_equal(dat_aligned, dat_aligned_man)
+    expect_identical(dat_aligned, dat_aligned_man)
 
     # align on 3 positions - full plan
 
@@ -971,7 +971,7 @@ test_that("multi-positional alignment", {
     )
     # nolint end
 
-    expect_equal(
+    expect_identical(
         dat_aligned,
         dat_aligned_man
     )
@@ -1010,7 +1010,7 @@ test_that("multi-positional alignment detects inadequate inputs", {
         apply_col_style_plan(dat_wide, tfrmt_obj)
     )
 
-    expect_equal(
+    expect_identical(
         msgs,
         c(
             "`align` input for `type`=\"pos\" in col_style_structure does not cover all possible values. Some cells may not be aligned.\n",
@@ -1050,7 +1050,7 @@ test_that("multi-positional alignment detects inadequate inputs", {
         apply_col_style_plan(dat_wide, tfrmt_obj)
     )
 
-    expect_equal(
+    expect_identical(
         msgs,
         c(
             "Unable to complete positional alignment in col_style_structure due to lack of whitespace available formatted value\n",
@@ -1102,7 +1102,7 @@ test_that("helper for constructing positional alignment works", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         display_val_frmts(
             tfrmt_obj,
             .data = dat,

--- a/tests/testthat/test-expr_to_filter.R
+++ b/tests/testthat/test-expr_to_filter.R
@@ -6,8 +6,8 @@ test_that("expr_to_filter - quosure", {
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
     filter_default <- expr_to_filter.quosure(cols = quo_val, val = default)
 
-    expect_equal(filter_var, "`col` %in% c(\"value1\")")
-    expect_equal(filter_default, "TRUE")
+    expect_identical(filter_var, "`col` %in% c(\"value1\")")
+    expect_identical(filter_default, "TRUE")
 })
 
 
@@ -25,8 +25,8 @@ test_that("expr_to_filter - quosures", {
     filter_var <- expr_to_filter.quosures(cols = quos_val_1, val = var)
     filter_default <- expr_to_filter.quosures(cols = quos_val_1, val = default)
 
-    expect_equal(filter_var, "`col1` %in% c(\"value1\")")
-    expect_equal(filter_default, "TRUE")
+    expect_identical(filter_var, "`col1` %in% c(\"value1\")")
+    expect_identical(filter_default, "TRUE")
 
     ## length 2 vars & length one var
 
@@ -38,7 +38,7 @@ test_that("expr_to_filter - quosures", {
     )
 
     ### .default is allowed
-    expect_equal(
+    expect_identical(
         expr_to_filter.quosures(cols = quos_val_2, val = default),
         "TRUE"
     )
@@ -53,11 +53,11 @@ test_that("expr_to_filter - quosures", {
         val = var_list_default
     )
 
-    expect_equal(
+    expect_identical(
         filter_var_list_named,
         "`col1` %in% c(\"value1\") & `col2` %in% c(\"value2\")"
     )
-    expect_equal(filter_var_list_default, "TRUE & `col2` %in% c(\"value2\")")
+    expect_identical(filter_var_list_default, "TRUE & `col2` %in% c(\"value2\")")
 
     ## length 2 vars & length two var incorrect names
     expect_error(
@@ -72,17 +72,17 @@ test_that("expr_to_filter - quosure - with quotes", {
 
     var <- "value1's"
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_equal(filter_var, "`col` %in% c(\"value1's\")")
+    expect_identical(filter_var, "`col` %in% c(\"value1's\")")
 
     var <- "value1's"
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_equal(filter_var, "`col` %in% c(\"value1's\")")
+    expect_identical(filter_var, "`col` %in% c(\"value1's\")")
 
     var <- '"a value with quotes"'
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_equal(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
+    expect_identical(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
 
     var <- "\"a value with quotes\""
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_equal(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
+    expect_identical(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
 })

--- a/tests/testthat/test-expr_to_filter.R
+++ b/tests/testthat/test-expr_to_filter.R
@@ -57,7 +57,10 @@ test_that("expr_to_filter - quosures", {
         filter_var_list_named,
         "`col1` %in% c(\"value1\") & `col2` %in% c(\"value2\")"
     )
-    expect_identical(filter_var_list_default, "TRUE & `col2` %in% c(\"value2\")")
+    expect_identical(
+        filter_var_list_default,
+        "TRUE & `col2` %in% c(\"value2\")"
+    )
 
     ## length 2 vars & length two var incorrect names
     expect_error(
@@ -80,9 +83,15 @@ test_that("expr_to_filter - quosure - with quotes", {
 
     var <- '"a value with quotes"'
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_identical(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
+    expect_identical(
+        filter_var,
+        "`col` %in% c(\"\\\"a value with quotes\\\"\")"
+    )
 
     var <- "\"a value with quotes\""
     filter_var <- expr_to_filter.quosure(cols = quo_val, val = var)
-    expect_identical(filter_var, "`col` %in% c(\"\\\"a value with quotes\\\"\")")
+    expect_identical(
+        filter_var,
+        "`col` %in% c(\"\\\"a value with quotes\\\"\")"
+    )
 })

--- a/tests/testthat/test-extract_data.R
+++ b/tests/testthat/test-extract_data.R
@@ -57,7 +57,7 @@ test_that("extract_data works for a single gt_tbl object", {
         select(-`..tfrmt_row_grp_lbl`)
 
     expect_s3_class(tfrmt_data_extracted, "data.frame")
-    expect_equal(tfrmt_data_extracted, tfrmt_data_manual)
+    expect_identical(tfrmt_data_extracted, tfrmt_data_manual)
     expect_gt(nrow(tfrmt_data_extracted), 0)
 })
 
@@ -137,7 +137,7 @@ test_that("extract_data extracts updated names changed in the col_plan including
         select(-`..tfrmt_row_grp_lbl`)
 
     expect_s3_class(tfrmt_data_extracted, "data.frame")
-    expect_equal(tfrmt_data_extracted, tfrmt_data_manual)
+    expect_identical(tfrmt_data_extracted, tfrmt_data_manual)
     expect_gt(nrow(tfrmt_data_extracted), 0)
 })
 
@@ -213,7 +213,7 @@ test_that("extract_data extracts updated names changed in the col_plan including
         select(-`..tfrmt_row_grp_lbl`)
 
     expect_s3_class(tfrmt_data_extracted, "data.frame")
-    expect_equal(tfrmt_data_extracted, tfrmt_data_manual)
+    expect_identical(tfrmt_data_extracted, tfrmt_data_manual)
     expect_gt(nrow(tfrmt_data_extracted), 0)
 })
 
@@ -287,7 +287,7 @@ test_that("extract_data extracts updated names changed in the col_plan", {
         select(-`..tfrmt_row_grp_lbl`)
 
     expect_s3_class(tfrmt_data_extracted, "data.frame")
-    expect_equal(tfrmt_data_extracted, tfrmt_data_manual)
+    expect_identical(tfrmt_data_extracted, tfrmt_data_manual)
     expect_gt(nrow(tfrmt_data_extracted), 0)
 })
 
@@ -364,7 +364,7 @@ test_that("extract_data works for a gt_group object (paged tables)", {
     #  Assertions
     expect_type(gt_group_data_extracted, "list")
     expect_length(gt_group_data_extracted, length(gt_group_manual))
-    expect_equal(gt_group_data_extracted, gt_group_manual)
+    expect_identical(gt_group_data_extracted, gt_group_manual)
 
     # Check that each element in the list is a data frame
     expect_s3_class(gt_group_data_extracted[[1]], "data.frame")
@@ -475,7 +475,7 @@ test_that("extract_data works for a table with bigN values", {
 
     # check expected data is equal to manual extraction
     expect_s3_class(extracted, "data.frame")
-    expect_equal(extracted, manual)
+    expect_identical(extracted, manual)
     expect_gt(nrow(extracted), 0)
 
     # check that the bigns are present in the column names of extracted data

--- a/tests/testthat/test-make_mock_data.R
+++ b/tests/testthat/test-make_mock_data.R
@@ -15,7 +15,10 @@ test_that("Mock data column names are correct", {
     )
     mock_dat <- make_mock_data(plan)
 
-    expect_identical(c("my_group", "my_label", "param2", "col"), names(mock_dat))
+    expect_identical(
+        c("my_group", "my_label", "param2", "col"),
+        names(mock_dat)
+    )
 })
 
 test_that("Mock data contains all levels", {

--- a/tests/testthat/test-make_mock_data.R
+++ b/tests/testthat/test-make_mock_data.R
@@ -15,7 +15,7 @@ test_that("Mock data column names are correct", {
     )
     mock_dat <- make_mock_data(plan)
 
-    expect_equal(c("my_group", "my_label", "param2", "col"), names(mock_dat))
+    expect_identical(c("my_group", "my_label", "param2", "col"), names(mock_dat))
 })
 
 test_that("Mock data contains all levels", {
@@ -36,7 +36,7 @@ test_that("Mock data contains all levels", {
     )
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -97,7 +97,7 @@ test_that("Mock data contains all levels", {
     )
     mock_dat <- make_mock_data(plan, .default = 1, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -134,7 +134,7 @@ test_that("Mock data contains all levels", {
     )
     mock_dat <- make_mock_data(plan, .default = 1, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -150,7 +150,7 @@ test_that("Mock data contains all levels", {
     # group & label specified + multiple levels/columns
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 2)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -200,7 +200,7 @@ test_that("Mock data contains all levels", {
     )
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -265,7 +265,7 @@ test_that("Mock data contains all levels", {
     )
     mock_dat2 <- make_mock_data(plan2, .default = 1:2, n_cols = 1)
 
-    expect_equal(mock_dat1, mock_dat2)
+    expect_identical(mock_dat1, mock_dat2)
 })
 
 
@@ -350,7 +350,7 @@ test_that("Test when no body_style or values is present", {
         fixed = TRUE
     )
 
-    expect_equal(
+    expect_identical(
         gt_out$`_data`,
         input_data %>%
             mutate(val = "X.X") %>%
@@ -384,7 +384,7 @@ test_that("Mock data contains sorting_cols when available", {
 
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -420,7 +420,7 @@ test_that("Mock data contains sorting_cols when available", {
 
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 1)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -457,7 +457,7 @@ test_that("Mock data includes all columns identified in tfrmt", {
 
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 2)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -492,7 +492,7 @@ test_that("Mock data includes all columns identified in tfrmt", {
 
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 2)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -527,7 +527,7 @@ test_that("Mock data includes all columns identified in tfrmt", {
 
     mock_dat <- make_mock_data(plan, .default = 1:2, n_cols = 2)
 
-    expect_equal(
+    expect_identical(
         mock_dat,
         # nolint start: commas_linter
         tibble::tribble(
@@ -566,7 +566,7 @@ test_that("Mock data can be made and printed without label", {
 
     dat <- make_mock_data(plan)
 
-    expect_equal(
+    expect_identical(
         dat,
         tibble(
             param = c("n", "n", "n", "percent", "percent", "percent"),
@@ -634,7 +634,7 @@ test_that("Using col_plan to get column names", {
     col_names <- make_mock_data(basic_cols) %>%
         pull(column) %>%
         unique()
-    expect_equal(col_names, c("Placebo", "Low", "High"))
+    expect_identical(col_names, c("Placebo", "Low", "High"))
 
     #With spanning
     auto_col_df <- tfrmt(
@@ -673,7 +673,7 @@ test_that("Using col_plan to get column names", {
         test1 = c(rep(NA, 3), rep(c("span 1", "span 2"), each = 2)),
         test2 = c("col4", "col3", "col5", "col1", "col2", "col7", "col8")
     )
-    expect_equal(auto_col_df, man_col_df)
+    expect_identical(auto_col_df, man_col_df)
 
     # When you do crossing in the span structure
     auto_col_crossing <- tfrmt(
@@ -716,7 +716,7 @@ test_that("Using col_plan to get column names", {
     )
     # nolint end
 
-    expect_equal(auto_col_crossing, man_col_crossing)
+    expect_identical(auto_col_crossing, man_col_crossing)
 })
 
 test_that("Using col_style_plan to get names", {
@@ -749,7 +749,7 @@ test_that("Using col_style_plan to get names", {
     col_names <- make_mock_data(basic_cols) %>%
         pull(column) %>%
         unique()
-    expect_equal(col_names, c("Active", "Placebo", "Total"))
+    expect_identical(col_names, c("Active", "Placebo", "Total"))
 
     # combination col_style_plan/col_plan
     auto_col_df <- tfrmt(
@@ -809,7 +809,7 @@ test_that("Using col_style_plan to get names", {
             "Total"
         )
     )
-    expect_equal(auto_col_df, man_col_df)
+    expect_identical(auto_col_df, man_col_df)
 })
 
 test_that("Will add big N avaliable", {
@@ -851,7 +851,7 @@ test_that("Will add big N avaliable", {
     )
     # nolint end
 
-    expect_equal(auto_big_n_df, man_big_n_df)
+    expect_identical(auto_big_n_df, man_big_n_df)
 })
 
 test_that("Mock data for col_plan with only drops", {
@@ -884,7 +884,7 @@ test_that("Mock data for col_plan with only drops", {
     make_mock_data(drop_tfrmt) %>%
         pull(column) %>%
         unique() %>%
-        expect_equal(c("column1", "column2", "column3"))
+        expect_identical(c("column1", "column2", "column3"))
 })
 
 test_that("Mock data for col_plan does not add group, label, or sorting_cols names to `column` variable", {
@@ -915,7 +915,7 @@ test_that("Mock data for col_plan does not add group, label, or sorting_cols nam
     make_mock_data(tf_cols) %>%
         pull(col) %>%
         unique() %>%
-        expect_equal(c("col1", "col2"))
+        expect_identical(c("col1", "col2"))
 })
 
 test_that("Mock data ignores col_plan with everything()", {
@@ -942,7 +942,7 @@ test_that("Mock data ignores col_plan with everything()", {
     col_names <- make_mock_data(tf_everything) %>%
         pull(column) %>%
         unique()
-    expect_equal(
+    expect_identical(
         col_names,
         c("column1", "column2", "column3")
     )

--- a/tests/testthat/test-mrkdown_labels.R
+++ b/tests/testthat/test-mrkdown_labels.R
@@ -65,7 +65,7 @@ test_that("markdown column labels - no spanning", {
         tab_options(container.width = 1000)
 
     # test that format of column headers is markdown
-    expect_equal(
+    expect_identical(
         lapply(test_tfrmt$`_boxhead`$column_label, attr, "class"),
         as.list(rep(
             "from_markdown",
@@ -138,14 +138,14 @@ test_that("markdown column labels - spanning", {
         print_to_gt(mock_data)
 
     # test that format of both column headers and spannning headers is markdown
-    expect_equal(
+    expect_identical(
         lapply(test_tfrmt$`_boxhead`$column_label, attr, "class"),
         as.list(rep(
             "from_markdown",
             length(test_tfrmt$`_boxhead`$column_label)
         ))
     )
-    expect_equal(
+    expect_identical(
         lapply(test_tfrmt$`_spanners`$spanner_label, attr, "class"),
         as.list(rep(
             "from_markdown",
@@ -200,7 +200,7 @@ test_that("markdown column labels - renamed", {
     ) %>%
         print_to_gt(mock_data)
 
-    expect_equal(
+    expect_identical(
         lapply(test_tfrmt$`_boxhead`$column_label, attr, "class"),
         as.list(rep(
             "from_markdown",

--- a/tests/testthat/test-print_to_gt.R
+++ b/tests/testthat/test-print_to_gt.R
@@ -11,15 +11,15 @@ test_that("convert_ws_unicode works as expected", {
     # test that metadata is present in gt ready to apply transform
 
     # columns to apply to
-    expect_equal(
+    expect_identical(
         gt_with_unicode$`_transforms`[[1]]$resolved$colnames,
         c("group", "value")
     )
 
     # rows to apply to
-    expect_equal(
+    expect_identical(
         gt_with_unicode$`_transforms`[[1]]$resolved$rows,
-        1
+        1L
     )
 
     # function to apply
@@ -46,7 +46,7 @@ test_that("convert_ws_unicode works as expected", {
         "trailing \u00A0whitespace\u00A0\u00A0\u00A0\u00A0\u00A0"
     )
 
-    expect_equal(
+    expect_identical(
         whitespace_function(test_strings),
         unicode_strings
     )

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -280,11 +280,11 @@ test_that("shuffle_card coerces all factor groups/variables to character", {
     expect_true(all(res_classes == "character"))
 
     # correct coersion
-    expect_equal(
+    expect_identical(
         sort(unique(res$RACE)),
         sort(unique(as.character(adsl_$RACE)))
     )
-    expect_equal(
+    expect_identical(
         sort(unique(res$ETHNIC)),
         sort(unique(as.character(adsl_$ETHNIC)))
     )

--- a/tests/testthat/test-tfmt.R
+++ b/tests/testthat/test-tfmt.R
@@ -5,12 +5,12 @@ test_that("basic tfrmt - title", {
 
     expect_s3_class(t_frmt, "tfrmt")
 
-    expect_equal(t_frmt$title, "Table Title")
-    expect_equal(t_frmt$group, vars())
-    expect_equal(t_frmt$label, quo())
-    expect_equal(t_frmt$param, quo())
-    expect_equal(t_frmt$value, quo())
-    expect_equal(t_frmt$column, vars())
+    expect_identical(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$group, vars())
+    expect_identical(t_frmt$label, quo())
+    expect_identical(t_frmt$param, quo())
+    expect_identical(t_frmt$value, quo())
+    expect_identical(t_frmt$column, vars())
 })
 
 test_that("basic tfrmt - selecting group/label/param/value/column - quo", {
@@ -25,7 +25,7 @@ test_that("basic tfrmt - selecting group/label/param/value/column - quo", {
 
     expect_s3_class(t_frmt, "tfrmt")
 
-    expect_equal(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$title, "Table Title")
     expect_equal(t_frmt$group, vars(row_label1), ignore_attr = TRUE)
     expect_equal(t_frmt$label, quo(row_label2), ignore_attr = TRUE)
     expect_equal(t_frmt$param, quo(param), ignore_attr = TRUE)
@@ -45,7 +45,7 @@ test_that("basic tfrmt - selecting group/label/param/value/column - quo into var
 
     expect_s3_class(t_frmt, "tfrmt")
 
-    expect_equal(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$title, "Table Title")
     expect_equal(t_frmt$group, vars(row_label1), ignore_attr = TRUE)
     expect_equal(t_frmt$label, quo(row_label2), ignore_attr = TRUE)
     expect_equal(t_frmt$param, quo(param), ignore_attr = TRUE)
@@ -65,7 +65,7 @@ test_that("basic tfrmt - selecting group/label/param/value/column - char", {
 
     expect_s3_class(t_frmt, "tfrmt")
 
-    expect_equal(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$title, "Table Title")
     expect_equal(t_frmt$group, vars(row_label1), ignore_attr = TRUE)
     expect_equal(t_frmt$label, quo(row_label2), ignore_attr = TRUE)
     expect_equal(t_frmt$param, quo(param), ignore_attr = TRUE)
@@ -84,7 +84,7 @@ test_that("basic tfrmt - selecting group/label/param/value/column - bare", {
     )
 
     expect_s3_class(t_frmt, "tfrmt")
-    expect_equal(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$title, "Table Title")
     expect_equal(t_frmt$group, vars(row_label1, row_label4), ignore_attr = TRUE)
     expect_equal(t_frmt$label, quo(row_label2), ignore_attr = TRUE)
     expect_equal(t_frmt$param, quo(param), ignore_attr = TRUE)
@@ -104,7 +104,7 @@ test_that("basic tfrmt - length one quo warning", {
         )
     })
 
-    expect_equal(
+    expect_identical(
         single_warning,
         paste0(
             "Passed more than one quosure to the argument `",
@@ -124,7 +124,7 @@ test_that("basic tfrmt - length one quo warning", {
         )
     })
 
-    expect_equal(
+    expect_identical(
         multi_warning,
         c(
             "Passed more than one quosure to the argument `label`. Selecting the first entry.",
@@ -174,21 +174,21 @@ test_that("layering tfrmt - default table elements - func/tfrmt", {
         "tfrmt"
     )
 
-    expect_equal(
+    expect_identical(
         t_frmt_layered$title,
         "Table Title"
     )
 
-    expect_equal(
+    expect_identical(
         t_frmt_layered$subtitle,
         "Table Subtitle"
     )
 
-    expect_equal(t_frmt_layered$group, vars())
-    expect_equal(t_frmt_layered$label, quo())
-    expect_equal(t_frmt_layered$param, quo())
-    expect_equal(t_frmt_layered$value, quo())
-    expect_equal(t_frmt_layered$column, vars())
+    expect_identical(t_frmt_layered$group, vars())
+    expect_identical(t_frmt_layered$label, quo())
+    expect_identical(t_frmt_layered$param, quo())
+    expect_identical(t_frmt_layered$value, quo())
+    expect_identical(t_frmt_layered$column, vars())
 })
 
 test_that("layering tfrmt - select latest table elements", {
@@ -205,8 +205,8 @@ test_that("layering tfrmt - select latest table elements", {
         )
 
     expect_s3_class(t_frmt_layered, "tfrmt")
-    expect_equal(t_frmt_layered$title, "Table Title 2")
-    expect_equal(t_frmt_layered$subtitle, "Table Subtitle")
+    expect_identical(t_frmt_layered$title, "Table Title 2")
+    expect_identical(t_frmt_layered$subtitle, "Table Subtitle")
 })
 
 test_that("layering tfrmt - body style elements", {
@@ -236,8 +236,8 @@ test_that("layering tfrmt - body style elements", {
 
     expect_s3_class(t_frmt_layered, "tfrmt")
 
-    expect_equal(t_frmt_layered$title, "Table Title")
-    expect_equal(
+    expect_identical(t_frmt_layered$title, "Table Title")
+    expect_identical(
         t_frmt_layered$body_plan,
         body_plan(
             frmt_structure(
@@ -287,10 +287,10 @@ test_that("layering tfrmt - body style elements - multiple", {
 
     expect_s3_class(t_frmt_layered, "tfrmt")
 
-    expect_equal(t_frmt_layered$title, "Table Title")
-    expect_equal(t_frmt_layered$subtitle, "Table Subtitle")
+    expect_identical(t_frmt_layered$title, "Table Title")
+    expect_identical(t_frmt_layered$subtitle, "Table Subtitle")
 
-    expect_equal(
+    expect_identical(
         t_frmt_layered$body_plan,
         body_plan(
             frmt_structure(
@@ -346,10 +346,10 @@ test_that("layering tfrmt - body style elements - join_body_style FALSE", {
 
     expect_s3_class(t_frmt_layered, "tfrmt")
 
-    expect_equal(t_frmt_layered$title, "Table Title")
-    expect_equal(t_frmt_layered$subtitle, "Table Subtitle")
+    expect_identical(t_frmt_layered$title, "Table Title")
+    expect_identical(t_frmt_layered$subtitle, "Table Subtitle")
 
-    expect_equal(
+    expect_identical(
         t_frmt_layered$body_plan,
         body_plan(
             frmt_structure(
@@ -382,8 +382,8 @@ test_that("layering tfrmt - keeping original var/quo", {
         )
 
     expect_s3_class(t_frmt_layered, "tfrmt")
-    expect_equal(t_frmt_layered$title, "Table Title 2")
-    expect_equal(t_frmt_layered$subtitle, "Table Subtitle")
+    expect_identical(t_frmt_layered$title, "Table Title 2")
+    expect_identical(t_frmt_layered$subtitle, "Table Subtitle")
     expect_equal(t_frmt_layered$group, vars(Group1, Group2), ignore_attr = TRUE)
     expect_equal(t_frmt_layered$label, quo(label1), ignore_attr = TRUE)
 })
@@ -405,8 +405,8 @@ test_that("layering tfrmt - Mixing var/quo", {
         )
 
     expect_s3_class(t_frmt_layered, "tfrmt")
-    expect_equal(t_frmt_layered$title, "Table Title 2")
-    expect_equal(t_frmt_layered$subtitle, "Table Subtitle")
+    expect_identical(t_frmt_layered$title, "Table Title 2")
+    expect_identical(t_frmt_layered$subtitle, "Table Subtitle")
     expect_equal(t_frmt_layered$group, vars(Group1, Group2), ignore_attr = TRUE)
     expect_equal(t_frmt_layered$label, quo(label3), ignore_attr = TRUE)
 })
@@ -418,7 +418,7 @@ test_that("basic tfrmt - ... args", {
             totally_fake_arg = "my_col"
         )
     )
-    expect_equal(
+    expect_identical(
         message_res,
         "Argument 'totally_fake_arg' passed to tfrmt is not a recognized argument."
     )
@@ -429,7 +429,7 @@ test_that("basic tfrmt - ... args", {
             colmn = "my_col"
         )
     )
-    expect_equal(
+    expect_identical(
         message_res,
         "Argument 'colmn' passed to tfrmt is not a recognized argument.\nDid you intend to use the argument `column`?"
     )
@@ -440,7 +440,7 @@ test_that("basic tfrmt - ... args", {
             lalbl = "label"
         )
     )
-    expect_equal(
+    expect_identical(
         message_res,
         c(
             "Argument 'colmn' passed to tfrmt is not a recognized argument.\nDid you intend to use the argument `column`?",
@@ -480,7 +480,7 @@ test_that("basic tfrmt - func calls into quo and var args", {
     )
 
     expect_s3_class(t_frmt, "tfrmt")
-    expect_equal(t_frmt$title, "Table Title")
+    expect_identical(t_frmt$title, "Table Title")
     expect_equal(t_frmt$group, vars(col, df), ignore_attr = TRUE)
     expect_equal(t_frmt$label, quo(runif), ignore_attr = TRUE)
     expect_equal(t_frmt$param, quo(abs), ignore_attr = TRUE)
@@ -559,25 +559,25 @@ test_that("advanced tfrmt - tfrmt maker", {
     )
 
     expect_s3_class(new_tfrmt, "tfrmt")
-    expect_equal(new_tfrmt$title, "Table Title")
+    expect_identical(new_tfrmt$title, "Table Title")
     expect_equal(new_tfrmt$group, vars(value1, value2), ignore_attr = TRUE)
     expect_equal(new_tfrmt$label, quo(labs), ignore_attr = TRUE)
     expect_equal(new_tfrmt$param, quo(parameter), ignore_attr = TRUE)
 
     expect_s3_class(new_tfrmt_char, "tfrmt")
-    expect_equal(new_tfrmt_char$title, "Table Title")
+    expect_identical(new_tfrmt_char$title, "Table Title")
     expect_equal(new_tfrmt_char$group, vars(value1, value2), ignore_attr = TRUE)
     expect_equal(new_tfrmt_char$label, quo(labs), ignore_attr = TRUE)
     expect_equal(new_tfrmt_char$param, quo(parameter), ignore_attr = TRUE)
 
     expect_s3_class(new_tfrmt_2, "tfrmt")
-    expect_equal(new_tfrmt_2$title, "Table Title")
+    expect_identical(new_tfrmt_2$title, "Table Title")
     expect_equal(new_tfrmt_2$group, vars(value1, value2), ignore_attr = TRUE)
     expect_equal(new_tfrmt_2$label, quo(labs), ignore_attr = TRUE)
     expect_equal(new_tfrmt_2$param, quo(parameter), ignore_attr = TRUE)
 
     expect_s3_class(new_tfrmt_2_char, "tfrmt")
-    expect_equal(new_tfrmt_2_char$title, "Table Title")
+    expect_identical(new_tfrmt_2_char$title, "Table Title")
     expect_equal(
         new_tfrmt_2_char$group,
         vars(value1, value2),
@@ -604,7 +604,7 @@ test_that("advanced tfrmt - tfrmt maker", {
     )
 
     expect_s3_class(new_tfrmt_with_bp, "tfrmt")
-    expect_equal(new_tfrmt_with_bp$title, "Table Title")
+    expect_identical(new_tfrmt_with_bp$title, "Table Title")
     expect_equal(
         new_tfrmt_with_bp$group,
         vars(value1, value2),
@@ -655,7 +655,7 @@ test_that("advanced tfrmt - tfrmt maker", {
     )
 
     expect_s3_class(new_tfrmt_with_bp_2, "tfrmt")
-    expect_equal(new_tfrmt_with_bp_2$title, "Table Title")
+    expect_identical(new_tfrmt_with_bp_2$title, "Table Title")
     expect_equal(
         new_tfrmt_with_bp_2$group,
         vars(value1, value2),

--- a/tests/testthat/test-tfrmt_n_pct.R
+++ b/tests/testthat/test-tfrmt_n_pct.R
@@ -1,6 +1,6 @@
 test_that("tfrmt_n_pct", {
     # format to avoid issues with the environment
-    expect_equal(
+    expect_identical(
         format(tfrmt_n_pct()$body_plan),
         body_plan(
             frmt_structure(
@@ -22,7 +22,7 @@ test_that("tfrmt_n_pct", {
             format()
     )
     # See that it can change when n is changed
-    expect_equal(
+    expect_identical(
         format(tfrmt_n_pct("n_distinct")$body_plan),
         body_plan(
             frmt_structure(
@@ -44,7 +44,7 @@ test_that("tfrmt_n_pct", {
             format()
     )
     # Change the frmt_when
-    expect_equal(
+    expect_identical(
         format(
             tfrmt_n_pct(
                 pct_frmt_when = frmt_when(
@@ -76,7 +76,7 @@ test_that("tfrmt_n_pct", {
     test <- tfrmt(
         column = column
     )
-    expect_equal(
+    expect_identical(
         tfrmt_n_pct(tfrmt_obj = test)$column[[1]] %>%
             as_label(),
         "column"

--- a/tests/testthat/test-tfrmt_sigdig.R
+++ b/tests/testthat/test-tfrmt_sigdig.R
@@ -6,7 +6,7 @@ test_that("setting param sigdig defaults", {
         "{mean} ({sd})" = c(1, 2),
         n = NA
     )
-    expect_equal(param_set(), defaults)
+    expect_identical(param_set(), defaults)
 
     # nolint start: yoda_test_linter
     expect_equal(
@@ -24,7 +24,7 @@ test_that("setting param sigdig defaults", {
     )
     # nolint end
 
-    expect_equal(
+    expect_identical(
         param_set(new_prm = 4),
         list(
             min = 1,
@@ -36,7 +36,7 @@ test_that("setting param sigdig defaults", {
         )
     )
 
-    expect_equal(
+    expect_identical(
         param_set(mean = 0),
         list(
             min = 1,
@@ -66,7 +66,7 @@ test_that("build frmt objects", {
         param = c("mean", "sd"),
         frmt_string = c("xx.x", "xx.xx")
     )
-    expect_equal(
+    expect_identical(
         frmt_spec,
         list(
             mean = frmt("xx.x"),
@@ -79,7 +79,7 @@ test_that("build frmt objects", {
         frmt_string = c("xx.x", "xx.xx"),
         missing = "--"
     )
-    expect_equal(
+    expect_identical(
         frmt_spec,
         list(
             mean = frmt("xx.x", missing = "--"),
@@ -92,7 +92,7 @@ test_that("build frmt objects", {
         missing = "--"
     )
 
-    expect_equal(
+    expect_identical(
         frmt_spec,
         list(
             frmt("xx.x", missing = "--"),
@@ -113,7 +113,7 @@ test_that("build frmt objects", {
         sd = frmt("xx.xx", missing = "-"),
         missing = "-"
     ))
-    expect_equal(frmt_spec, frmt_string)
+    expect_identical(frmt_spec, frmt_string)
 
     # frmt_structure
     frmt_list <- list(
@@ -152,7 +152,7 @@ test_that("build frmt objects", {
         )
     )
 
-    expect_equal(frmt_spec, frmt_string)
+    expect_identical(frmt_spec, frmt_string)
 
     frmt_spec <- frmt_structure_builder(
         group_val = ".default",
@@ -180,7 +180,7 @@ test_that("build frmt objects", {
             n = frmt("xxx")
         )
     )
-    expect_equal(frmt_spec, frmt_string)
+    expect_identical(frmt_spec, frmt_string)
 
     # build contents of body_plan for a given sigdig value
     # nolint start: commas_linter
@@ -228,7 +228,7 @@ test_that("build frmt objects", {
             n = frmt("x")
         )
     )
-    expect_equal(bp_1grp_1lbl, bp_1grp_1lbl_man)
+    expect_identical(bp_1grp_1lbl, bp_1grp_1lbl_man)
 
     # 2 groups, no label
     bp_2grp_0lbl <- body_plan_builder(
@@ -283,7 +283,7 @@ test_that("build frmt objects", {
             n = frmt("x")
         )
     )
-    expect_equal(bp_2grp_0lbl, bp_2grp_0lbl_man)
+    expect_identical(bp_2grp_0lbl, bp_2grp_0lbl_man)
 
     # custom params
     bp_prm <- body_plan_builder(
@@ -332,7 +332,7 @@ test_that("build frmt objects", {
             pct = frmt("x.x%")
         )
     )
-    expect_equal(bp_prm, bp_prm_man)
+    expect_identical(bp_prm, bp_prm_man)
 
     # custom params
     bp_prm <- body_plan_builder(
@@ -373,7 +373,7 @@ test_that("build frmt objects", {
         )
     )
 
-    expect_equal(bp_prm, bp_prm_man)
+    expect_identical(bp_prm, bp_prm_man)
 })
 
 test_that("no redundant frmt_structures", {
@@ -483,7 +483,7 @@ test_that("no redundant frmt_structures", {
             n = frmt("x")
         )
     )
-    expect_equal(bp, bp_man)
+    expect_identical(bp, bp_man)
 
     # nolint start: commas_linter
     dat_sigdig <- tibble::tribble(
@@ -679,7 +679,7 @@ test_that("no redundant frmt_structures", {
         )
     )
 
-    expect_equal(bp, bp_man)
+    expect_identical(bp, bp_man)
 })
 
 
@@ -744,7 +744,7 @@ test_that("varying group/label inputs", {
         ignore_attr = TRUE
     )
 
-    expect_equal(
+    expect_identical(
         t_out$label,
         quo()
     )
@@ -855,7 +855,7 @@ test_that("group vars specified in tfrmt but not sigdig data are represented in 
         )
     )
 
-    expect_equal(bp, bp_man)
+    expect_identical(bp, bp_man)
 
     expect_warning(
         bp <- tfrmt_sigdig(
@@ -920,7 +920,7 @@ test_that("group vars specified in tfrmt but not sigdig data are represented in 
         )
     )
 
-    expect_equal(bp, bp_man)
+    expect_identical(bp, bp_man)
 })
 
 test_that("tfrmt_sigdig can be layered onto another tfrmt", {
@@ -946,11 +946,11 @@ test_that("tfrmt_sigdig can be layered onto another tfrmt", {
         tfrmt_obj = prev_tfrmt
     )
 
-    expect_equal(
+    expect_identical(
         new_tfrmt$group,
         prev_tfrmt$group
     )
-    expect_equal(
+    expect_identical(
         new_tfrmt$lblvar,
         prev_tfrmt$lblvar
     )
@@ -1007,7 +1007,7 @@ test_that("tfrmt_sigdig can be layered onto another tfrmt", {
         )
     )
 
-    expect_equal(new_tfrmt$body_plan, bp_man)
+    expect_identical(new_tfrmt$body_plan, bp_man)
 
     prev_tfrmt <- tfrmt(
         group = somegrp,
@@ -1093,5 +1093,5 @@ test_that("tfrmt_sigdig correctly passes the 'missing' argument to the body_plan
         )
     )
 
-    expect_equal(bp_actual, bp_man)
+    expect_identical(bp_actual, bp_man)
 })

--- a/tests/testthat/test-utils_cards.R
+++ b/tests/testthat/test-utils_cards.R
@@ -60,13 +60,13 @@ test_that("get_card_attr_arg extracts attributes properly", {
     )
 
     # Default "by" argument
-    expect_equal(
+    expect_identical(
         get_card_attr_arg(mock_card),
         "group_var"
     )
 
     # Custom argument extraction
-    expect_equal(
+    expect_identical(
         get_card_attr_arg(mock_card, arg = "strata"),
         "age_strata"
     )
@@ -86,14 +86,14 @@ test_that("set_card_args modifies parameters properly", {
 
     # Modify an existing attribute element
     modified_card <- set_card_args(mock_card, "by", "new")
-    expect_equal(
+    expect_identical(
         attr(modified_card, "args")$by,
         "new"
     )
 
     # Add a new attribute element
     modified_card <- set_card_args(modified_card, "variable", "var_name")
-    expect_equal(
+    expect_identical(
         attr(modified_card, "args")$variable,
         "var_name"
     )
@@ -116,11 +116,11 @@ test_that("drop_bind_ard_args clears stale args on bind_ard objects", {
     expect_null(attr(cleaned, "args")$by)
     expect_null(attr(cleaned, "args")$variable)
     expect_null(attr(cleaned, "args")$strata)
-    expect_equal(attr(cleaned, "args")$leave_me, "keep")
+    expect_identical(attr(cleaned, "args")$leave_me, "keep")
 
     # Case 2: Object is a bind_ard but has NO args attribute -> should do nothing without crashing
     mock_no_args <- structure(data.frame(), class = "bind_ard")
-    expect_equal(drop_bind_ard_args(mock_no_args), mock_no_args)
+    expect_identical(drop_bind_ard_args(mock_no_args), mock_no_args)
 
     # Case 3: Object is NOT a bind_ard -> should leave args untouched
     mock_regular_card <- structure(
@@ -131,7 +131,7 @@ test_that("drop_bind_ard_args clears stale args on bind_ard objects", {
             variable = "bmi"
         )
     )
-    expect_equal(
+    expect_identical(
         drop_bind_ard_args(mock_regular_card),
         mock_regular_card
     )

--- a/tests/testthat/test-utils_tfrmt.R
+++ b/tests/testthat/test-utils_tfrmt.R
@@ -370,7 +370,7 @@ test_that("Check apply_tfrmt for mock data", {
         capture_messages()
 
     ## capturing second message
-    expect_equal(
+    expect_identical(
         make_mock_dat_message,
         "Mock data contains more than 1 param per unique label value. Param values will appear in separate rows.\n"
     )

--- a/tests/testthat/test_print_to_ggplot.R
+++ b/tests/testthat/test_print_to_ggplot.R
@@ -112,7 +112,7 @@ test_that("group columns are created correctly", {
         `..tfrmt_row_grp_lbl` = c(TRUE, rep(FALSE, 12))
     )
 
-    expect_equal(apply_grp_ggplot(test_data, tfrmt), expected_data)
+    expect_identical(apply_grp_ggplot(test_data, tfrmt), expected_data)
 })
 
 test_that("tfrmt is as expected", {
@@ -258,5 +258,5 @@ test_that("column type has been preserved", {
 
     expect_s3_class(table_data$column, class(x2$data$column))
     # risk$time is numeric (not an S3 object), so expect_s3_class cannot be used here
-    expect_equal(class(risk$time), class(p2$data$column)) # nolint: expect_s3_class_linter.
+    expect_identical(class(risk$time), class(p2$data$column)) # nolint: expect_s3_class_linter.
 })


### PR DESCRIPTION
Convert expect_equal() to expect_identical() at 290 lintr-flagged locations across 21 test files, per the expect_identical_linter rule. Adjusted a handful of expected literals to integer type (0L/1L/etc.) where expect_identical's strict type-checking exposed int vs double mismatches that expect_equal previously masked.

resolves #779 