### PR TITLE
enable `unnecessary_lambda_linter` 

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -10,7 +10,6 @@ linters: all_linters(
   todo_comment_linter = NULL,
   function_argument_linter = NULL,
   implicit_integer_linter = NULL,
-  unnecessary_lambda_linter = NULL,
   object_name_linter = NULL,
   # redundancy linters
   nonportable_path_linter = NULL,

--- a/.lintr_restrictive
+++ b/.lintr_restrictive
@@ -10,7 +10,6 @@ linters: all_linters(
   todo_comment_linter = NULL,
   function_argument_linter = NULL,
   implicit_integer_linter = NULL,
-  unnecessary_lambda_linter = NULL,
   object_name_linter = NULL,
   # redundancy linters
   nonportable_path_linter = NULL,

--- a/R/JSON.R
+++ b/R/JSON.R
@@ -166,9 +166,8 @@ as_json.col_plan <- function(x) {
 as_json.span_structure <- function(x) {
     purrr::map(
         x,
-        function(foo) {
-            purrr::map_chr(foo, as_json)
-        }
+        purrr::map_chr,
+        as_json
     ) %>%
         list(span_structure = .)
 }

--- a/R/apply_col_plan.R
+++ b/R/apply_col_plan.R
@@ -1,6 +1,6 @@
 apply_col_plan <- function(data, col_selection, grp_lbl) {
     if (is.character(col_selection)) {
-        quo_col_selections <- purrr::map(col_selection, ~ char_as_quo(.x))
+        quo_col_selections <- purrr::map(col_selection, char_as_quo)
         col_selection <- do.call(vars, quo_col_selections)
     }
 
@@ -95,7 +95,7 @@ create_col_order <- function(data_names, columns, cp) {
         }
     }
 
-    quo_col_selections <- purrr::map(col_selections, ~ char_as_quo(.x))
+    quo_col_selections <- purrr::map(col_selections, char_as_quo)
 
     do.call(vars, quo_col_selections)
 }

--- a/R/apply_page_plan.R
+++ b/R/apply_page_plan.R
@@ -40,13 +40,11 @@ apply_page_plan <- function(
             .data <- structure(
                 purrr::map(
                     .data,
-                    ~ apply_page_max_rows(
-                        .x,
-                        page_plan$max_rows,
-                        group,
-                        label,
-                        row_grp_plan_label_loc
-                    )
+                    apply_page_max_rows,
+                    page_plan$max_rows,
+                    group,
+                    label,
+                    row_grp_plan_label_loc
                 ) %>%
                     purrr::list_flatten(),
                 .page_grp_vars = attr(.data, ".page_grp_vars")
@@ -342,7 +340,8 @@ apply_page_struct <- function(
         dplyr::mutate(
             `..tfrmt_data` = purrr::map(
                 .data$`..tfrmt_data`,
-                ~ dplyr::select(.x, -"TEMP_row")
+                dplyr::select,
+                -"TEMP_row"
             )
         ) %>%
         dplyr::pull(.data$`..tfrmt_data`)

--- a/R/apply_row_grp_plan.R
+++ b/R/apply_row_grp_plan.R
@@ -296,7 +296,7 @@ combine_group_cols <- function(
                 run_id = dplyr::consecutive_id(!!!top_grouping)
             ) %>%
             dplyr::group_split() %>%
-            purrr::map(~ dplyr::select(.x, -run_id))
+            purrr::map(dplyr::select, -run_id)
 
         .data <- split_dat %>%
             purrr::map_dfr(function(lone_dat) {

--- a/R/big_n.R
+++ b/R/big_n.R
@@ -83,7 +83,7 @@ apply_big_n_df <- function(big_n_df, col_plan_vars, columns, value) {
             preselected_cols = c(),
             column_names = col_lab
         ) |>
-            purrr::map(~ char_as_quo(.x)) |>
+            purrr::map(char_as_quo) |>
             do.call("vars", args = _)
     } else {
         out <- col_plan_vars
@@ -244,7 +244,8 @@ get_big_ns <- function(.data, param, value, columns, big_n_structure, mock) {
                     dplyr::group_by(.data$`..tfrmt_big_n_order..`) |>
                     dplyr::group_split() |>
                     purrr::map(
-                        ~ dplyr::select(.x, -"..tfrmt_big_n_order..")
+                        dplyr::select,
+                        -"..tfrmt_big_n_order.."
                     )
             }
         }

--- a/R/frmt_utils.R
+++ b/R/frmt_utils.R
@@ -375,7 +375,7 @@ as.character.frmt_when <- function(x, ...) {
         })
 
     left <- x$frmt_ls %>%
-        purrr::map_chr(~ rlang::f_lhs(.x)) %>%
+        purrr::map_chr(rlang::f_lhs) %>%
         stringr::str_c("'", ., "'")
     params <- stringr::str_c(left, " ~ ", right) %>%
         stringr::str_c(collapse = ", ")
@@ -397,7 +397,7 @@ as.character.frmt_when <- function(x, ...) {
 #' @export
 as.character.frmt_combine <- function(x, ...) {
     params <- x$frmt_ls %>%
-        purrr::map_chr(~ as.character(.x)) %>%
+        purrr::map_chr(as.character) %>%
         stringr::str_c(names(x$frmt_ls), " = ", .) %>%
         stringr::str_c(collapse = ", ")
     paste0(

--- a/R/mock_tbl.R
+++ b/R/mock_tbl.R
@@ -233,7 +233,7 @@ make_col_df <- function(
                 purrr::keep(is.list) %>%
                 purrr::map_dfr(function(x) {
                     span_df <- x %>%
-                        purrr::map(~ clean_col_names(., c())) %>%
+                        purrr::map(clean_col_names, c()) %>%
                         purrr::reduce(tidyr::crossing) %>%
                         tidyr::unnest(cols = tidyselect::everything())
                     names(span_df) <- names(x)

--- a/R/print_to_gt.R
+++ b/R/print_to_gt.R
@@ -183,7 +183,7 @@ cleaned_data_to_gt <- function(.data, tfrmt, .unicode_ws) {
 #'
 #' @keywords internal
 cleaned_data_to_gt.list <- function(.data, tfrmt, .unicode_ws) {
-    purrr::map(.data, ~ cleaned_data_to_gt.default(.x, tfrmt, .unicode_ws)) %>%
+    purrr::map(.data, cleaned_data_to_gt.default, tfrmt, .unicode_ws) %>%
         gt::gt_group(.list = .)
 }
 #' Apply formatting to a single table
@@ -478,7 +478,7 @@ format_gt_column_labels <- function(gt_table, .data) {
             dplyr::group_by(.data$value) %>%
             tidyr::nest(set = "cols") %>%
             dplyr::mutate(
-                set = purrr::map(.data$set, ~ dplyr::pull(., .data$cols))
+                set = purrr::map(.data$set, dplyr::pull, .data$cols)
             ) %>%
             dplyr::filter(
                 .data$value != "NA"

--- a/R/struct_utils.R
+++ b/R/struct_utils.R
@@ -115,7 +115,7 @@ struct_val_idx <- function(cur_struct, .data, group, label) {
             ) %>%
             dplyr::group_by(.data$breaks) %>%
             dplyr::group_split() %>%
-            purrr::map(function(x) dplyr::pull(x, .data$TEMP_row))
+            purrr::map(dplyr::pull, .data$TEMP_row)
     } else {
         .data %>%
             dplyr::pull(.data$TEMP_row) %>%

--- a/tests/testthat/test-apply_page_plan.R
+++ b/tests/testthat/test-apply_page_plan.R
@@ -81,7 +81,7 @@ test_that("Page plan with grouped split", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("grp: A", "grp: B", "grp: C")
     )
     expect_identical(
@@ -135,7 +135,7 @@ test_that("Page plan with grouped split", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("grp2: a", "grp2: b")
     )
 
@@ -192,7 +192,7 @@ test_that("Page plan with grouped split", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c(
             "grp1: A, grp2: a",
             "grp1: A, grp2: b",
@@ -247,7 +247,7 @@ test_that("Page plan with grouped split", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("lbl: n", "lbl: pct")
     )
     expect_identical(
@@ -370,7 +370,7 @@ test_that("page plan with mix of defined & group splits", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("grp1: A", "grp1: A", "grp1: B", "grp1: B")
     )
     expect_identical(
@@ -451,7 +451,7 @@ test_that("page plan with multiple structures", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("grp1: A", "grp1: A", "grp1: A", "grp1: B", "grp1: B", "grp1: B")
     )
     expect_identical(
@@ -830,7 +830,7 @@ test_that("page plan with both page_structure and max_rows", {
     )
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c(
             "grp1: cat_1",
             "grp1: cat_2",
@@ -906,7 +906,7 @@ test_that("page plan with page_structure, single level variable", {
     expect_equal(auto_split, man_split, ignore_attr = TRUE)
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("grp1: cat_1")
     )
 })
@@ -958,7 +958,7 @@ test_that("page_plan() with transform", {
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("group 1: cat_1")
     )
 
@@ -972,7 +972,7 @@ test_that("page_plan() with transform", {
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c("group 1: category 1")
     )
 })
@@ -1022,7 +1022,7 @@ test_that("page_plan() with transform and multiple 'page by' variables", {
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c(
             "grp1: cat_1, grp2: cat_1",
             "grp1: cat_1, grp2: cat_2",
@@ -1054,7 +1054,7 @@ test_that("page_plan() with transform and multiple 'page by' variables", {
     auto_split <- apply_tfrmt(test_data, tfrmt_plan)
 
     expect_identical(
-        purrr::map_chr(auto_split, ~ attr(.x, ".page_note")),
+        purrr::map_chr(auto_split, attr, ".page_note"),
         c(
             "Group 1 (cat_1), Group 2 (cat_1)",
             "Group 1 (cat_1), Group 2 (cat_2)",
@@ -1295,7 +1295,8 @@ test_that("apply_page_plan() with label transformation in a complex table", {
     expect_identical(
         purrr::map_chr(
             auto_split,
-            ~ attr(.x, ".page_note")
+            attr,
+            ".page_note"
         ),
         c(
             "Group: Placebo (N=86)",
@@ -1314,7 +1315,8 @@ test_that("apply_page_plan() with label transformation in a complex table", {
     expect_identical(
         purrr::map_chr(
             auto_split,
-            ~ attr(.x, ".page_note")
+            attr,
+            ".page_note"
         ),
         c(
             "Group: Placebo (N=86)",
@@ -1332,7 +1334,8 @@ test_that("apply_page_plan() with label transformation in a complex table", {
     expect_identical(
         purrr::map_chr(
             auto_split,
-            ~ attr(.x, ".page_note")
+            attr,
+            ".page_note"
         ),
         c(
             "Treatment: Placebo (N=86)",

--- a/tests/testthat/test-big_n.R
+++ b/tests/testthat/test-big_n.R
@@ -1553,7 +1553,8 @@ test_that("Two grouping variables with a page_plan work as expected (renamed var
     expect_identical(
         purrr::map_chr(
             output_list,
-            ~ attr(.x, ".page_note")
+            attr,
+            ".page_note"
         ),
         c(
             "by group: 101",


### PR DESCRIPTION
- Replace lambda functions with direct function references in purrr::map calls
- Simplify code by passing functions directly instead of wrapping in ~ .x
- Updates in R files: apply_col_plan, apply_page_plan, apply_row_grp_plan, big_n, frmt_utils, JSON, mock_tbl, print_to_gt, struct_utils
- Updates in test files: test-apply_page_plan, test-big_n

resolves #830 