### PR TITLE
Fix shuffle_card handling for ard_stack by attributes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     tidyr,
     tidyselect
 Suggests:
-    cards (>= 0.8.0),
+    cards (>= 0.9.0),
     covr,
     ggfortify,
     knitr,

--- a/R/shuffle_card.R
+++ b/R/shuffle_card.R
@@ -63,7 +63,7 @@ shuffle_card <- function(
 
     # Check if a 'by' variable is available for bind_ard objs
     by_arg <- get_card_attr_arg(x, "by")
-    if (is_bind_ard_card(x) && rlang::is_empty(by)) {
+    if (is_bind_ard_card(x) && !is_ard_stack_card(x) && rlang::is_empty(by)) {
         by_msg <- if (rlang::is_empty(by_arg)) {
             c(
                 "*" = "If you want to use a grouping variable, pass it explicitly via the {.arg by} argument."

--- a/R/utils_cards.R
+++ b/R/utils_cards.R
@@ -95,7 +95,11 @@ set_card_args <- function(x, name, value) {
 #'   from 'bind_ard' and contains an 'args' attribute.
 #' @noRd
 drop_bind_ard_args <- function(x) {
-    if (is_bind_ard_card(x) && !is_ard_stack_card(x) && !is.null(attr(x, "args"))) {
+    if (
+        is_bind_ard_card(x) &&
+            !is_ard_stack_card(x) &&
+            !is.null(attr(x, "args"))
+    ) {
         x <- set_card_args(x, "by", NULL)
         x <- set_card_args(x, "variable", NULL)
         x <- set_card_args(x, "strata", NULL)

--- a/R/utils_cards.R
+++ b/R/utils_cards.R
@@ -56,6 +56,15 @@ is_bind_ard_card <- function(x) {
     inherits(x, "bind_ard")
 }
 
+#' Check if an object inherits from 'ard_stack'
+#'
+#' @param x An object to check.
+#' @return `TRUE` if the object inherits from 'ard_stack', `FALSE` otherwise.
+#' @noRd
+is_ard_stack_card <- function(x) {
+    inherits(x, "ard_stack")
+}
+
 #' Extract an argument from card attributes
 #'
 #' @param x a card object (data frame)
@@ -86,7 +95,7 @@ set_card_args <- function(x, name, value) {
 #'   from 'bind_ard' and contains an 'args' attribute.
 #' @noRd
 drop_bind_ard_args <- function(x) {
-    if (is_bind_ard_card(x) && !is.null(attr(x, "args"))) {
+    if (is_bind_ard_card(x) && !is_ard_stack_card(x) && !is.null(attr(x, "args"))) {
         x <- set_card_args(x, "by", NULL)
         x <- set_card_args(x, "variable", NULL)
         x <- set_card_args(x, "strata", NULL)

--- a/tests/testthat/test-shuffle_card.R
+++ b/tests/testthat/test-shuffle_card.R
@@ -661,7 +661,8 @@ test_that("shuffle_card() preserves the attributes of a `card` object", {
         attributes(shuffled_ard)[["args"]]
     )
 
-    # ard_stack uses bind_ard under the hood - attributes will be lost
+    # ard_stack uses bind_ard under the hood, but retains its ard_stack class
+    # so by attributes should be preserved
     ard <- cards::ard_stack(
         data = adsl,
         cards::ard_tabulate(variables = "AGEGR1"),
@@ -669,9 +670,10 @@ test_that("shuffle_card() preserves the attributes of a `card` object", {
         .by = "ARM"
     )
 
-    expect_snapshot(
+    expect_silent(
         shuffled_ard <- shuffle_card(ard)
     )
+    expect_true("ARM" %in% names(shuffled_ard))
 
     # Binding two ARDs together class without a by attribute
     ard_no_by_attr <- cards::bind_ard(


### PR DESCRIPTION
Keep by args for ard_stack objects while preserving defensive cleanup for plain bind_ard, and update shuffle_card messaging/tests accordingly.

resolves #799 

Note: This cant be merged until cards is released