### PR TITLE
Apply dragos's review suggestions from PR #824

### DIFF
--- a/R/apply_col_style_plan.R
+++ b/R/apply_col_style_plan.R
@@ -272,7 +272,7 @@ apply_col_alignment_pos <- function(col, align) {
         dplyr::left_join(
             tibble::tibble(
                 align = trimws(align),
-                col_as_x = stringr::str_replace_all(align, "\\|", "")
+                col_as_x = stringr::str_remove_all(align, stringr::fixed("|"))
             ),
             by = "col_as_x"
         )
@@ -328,7 +328,10 @@ apply_col_alignment_pos <- function(col, align) {
                 is.na(.data$col_split_val) ~ NA,
                 TRUE ~ dplyr::lag(.data$col_split_end, default = 0) + 1
             ),
-            col_split_lev = gsub("col_split_", "", .data$col_split_lev) %>%
+            col_split_lev = stringr::str_remove_all(
+                .data$col_split_lev,
+                stringr::fixed("col_split_")
+            ) %>%
                 as.numeric()
         )
 

--- a/R/apply_col_style_plan.R
+++ b/R/apply_col_style_plan.R
@@ -273,8 +273,9 @@ apply_col_alignment_pos <- function(col, align) {
             tibble::tibble(
                 align = trimws(align),
                 col_as_x = stringr::str_remove_all(
-                  align, 
-                  stringr::fixed("|"))
+                    align,
+                    stringr::fixed("|")
+                )
             ),
             by = "col_as_x"
         )

--- a/R/display_insights.R
+++ b/R/display_insights.R
@@ -145,15 +145,19 @@ display_row_frmts <- function(tfrmt, .data, convert_to_txt = TRUE) {
             dplyr::mutate(
                 frmt_details = dplyr::case_when(
                     frmt_type == "frmt" ~ frmt_details %>%
-                        stringr::str_remove("< frmt \\| Expression: ") %>%
-                        stringr::str_remove(" >"),
+                        stringr::str_remove(
+                            stringr::fixed("< frmt | Expression: ")
+                        ) %>%
+                        stringr::str_remove(stringr::fixed(" >")),
                     frmt_type == "frmt_combine" ~ frmt_details %>%
                         stringr::str_remove(
-                            "< frmt_combine \\| Expression: "
+                            stringr::fixed("< frmt_combine | Expression: ")
                         ) %>%
-                        stringr::str_remove(" >"),
+                        stringr::str_remove(stringr::fixed(" >")),
                     frmt_type == "frmt_when" ~ frmt_details %>%
-                        stringr::str_remove("< frmt_when \\| ") %>%
+                        stringr::str_remove(
+                            stringr::fixed("< frmt_when | ")
+                        ) %>%
                         stringr::str_sub(end = -2L) %>%
                         stringr::str_remove_all("[\n]") %>%
                         stringr::str_trim() %>%


### PR DESCRIPTION
- Replace str_replace_all() with str_remove_all() for removing patterns
- Replace gsub() with str_remove_all() for consistency with stringr functions
- Use stringr::fixed() for literal string matching instead of regex patterns
- Improve code formatting and alignment in display_insights.R

These changes address suggestions from code review on PR #824 (enable \ixed_regex_linter\).