### PR TITLE
fix span structure empty inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## Bug fixes
 * Robustly check that all required inputs (column, param, and value) are supplied to prevent unhelpful errors during table printing (#660).
-* `span_structure()` now gives a clear error when called with no arguments, rather than a confusing "must be named" message (#639).
+* `span_structure()` now gives a clear error when called with no arguments (#639).
 
 
 # tfrmt 0.4.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## Bug fixes
 * Robustly check that all required inputs (column, param, and value) are supplied to prevent unhelpful errors during table printing (#660).
+* `span_structure()` now gives a clear error when called with no arguments, rather than a confusing "must be named" message (#639).
 
 
 # tfrmt 0.4.0

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -196,6 +196,9 @@ check_span_structure_dots <- function(x) {
                         )
                     }
                 } else if (is.character(x)) {
+                    if (!nzchar(x)) {
+                        return(NULL) # nolint: return_linter
+                    }
                     return(as_length_one_quo.character(x)) # nolint: return_linter
                 } else {
                     rlang::abort(
@@ -215,10 +218,7 @@ check_span_structure_values <- function(
     call = rlang::caller_env()
 ) {
     is_empty_entry <- function(e) {
-        length(e) == 0 ||
-            (length(e) == 1 &&
-                rlang::is_quosure(e[[1]]) &&
-                identical(rlang::as_label(e[[1]]), ""))
+        length(e) == 0
     }
 
     empty_entries <- names(x)[sapply(x, is_empty_entry)]

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -147,6 +147,13 @@ is_span_structure <- function(x) {
 
 #' @noRd
 check_span_structure_dots <- function(x) {
+    if (length(x) == 0) {
+        rlang::abort(
+            "span_structure() requires at least one named argument.",
+            call = rlang::caller_call()
+        )
+    }
+
     x_names <- names(x)
 
     if (is.null(x_names) || !all(nzchar(x_names))) {

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -218,7 +218,7 @@ check_span_structure_values <- function(
     call = rlang::caller_env()
 ) {
     is_empty_entry <- function(e) {
-        length(e) == 0
+      length(e) == 0 || all(vapply(e, is.null, logical(1)))
     }
 
     empty_entries <- names(x)[sapply(x, is_empty_entry)]

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -195,12 +195,6 @@ check_span_structure_dots <- function(x) {
                         )
                     }
                 } else if (is.character(x)) {
-                    if (!nzchar(x)) {
-                        rlang::abort(
-                            "Empty string values are not allowed in span_structure().",
-                            call = rlang::caller_call()
-                        )
-                    }
                     return(as_length_one_quo.character(x)) # nolint: return_linter
                 } else {
                     rlang::abort(
@@ -211,7 +205,12 @@ check_span_structure_dots <- function(x) {
             })
         )
 
-    empty_entries <- names(x_dots)[sapply(x_dots, function(e) length(e) == 0)]
+    is_empty_entry <- function(e) {
+        length(e) == 0 ||
+            (length(e) == 1 && rlang::is_quosure(e[[1]]) && identical(rlang::as_label(e[[1]]), ""))
+    }
+
+    empty_entries <- names(x_dots)[sapply(x_dots, is_empty_entry)]
     if (length(empty_entries) > 0) {
         rlang::abort(
             paste0(

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -134,6 +134,7 @@ col_plan <- function(..., .drop = FALSE) {
 span_structure <- function(...) {
     span_cols <- as.list(substitute(substitute(...)))[-1]
     span_cols <- check_span_structure_dots(span_cols)
+    check_span_structure_values(span_cols)
 
     structure(
         span_cols,
@@ -205,23 +206,33 @@ check_span_structure_dots <- function(x) {
             })
         )
 
+    x_dots[!sapply(x_dots, is.null)]
+}
+
+#' @noRd
+check_span_structure_values <- function(
+    x,
+    call = rlang::caller_env()
+) {
     is_empty_entry <- function(e) {
         length(e) == 0 ||
-            (length(e) == 1 && rlang::is_quosure(e[[1]]) && identical(rlang::as_label(e[[1]]), ""))
+            (length(e) == 1 &&
+                rlang::is_quosure(e[[1]]) &&
+                identical(rlang::as_label(e[[1]]), ""))
     }
 
-    empty_entries <- names(x_dots)[sapply(x_dots, is_empty_entry)]
+    empty_entries <- names(x)[sapply(x, is_empty_entry)]
     if (length(empty_entries) > 0) {
         rlang::abort(
             paste0(
                 "The following span_structure() arguments have no column values: ",
                 paste0("`", empty_entries, "`", collapse = ", ")
             ),
-            call = rlang::caller_call()
+            call = call
         )
     }
 
-    x_dots[!sapply(x_dots, is.null)]
+    invisible(NULL)
 }
 
 is_valid_span_structure_call <- function(x) {

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -34,7 +34,8 @@
 #' @param ... For a col_plan and span_structure,
 #'   <[`tidy-select`][dplyr::dplyr_tidy_select]> arguments, unquoted expressions
 #'   separated by commas, and span_structures. span_structures must have the
-#'   arguments named to match the name the column in the input data has to identify the correct columns. See the examples
+#'   arguments named to match the name the column in the input data has to identify the correct columns.
+#'   Each named span entry must include at least one column value; empty values such as "" or c() are not allowed.See the examples
 #' @param .drop Boolean. Should un-listed columns be dropped from the data.
 #'   Defaults to FALSE.
 #'

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -195,6 +195,12 @@ check_span_structure_dots <- function(x) {
                         )
                     }
                 } else if (is.character(x)) {
+                    if (!nzchar(x)) {
+                        rlang::abort(
+                            "Empty string values are not allowed in span_structure().",
+                            call = rlang::caller_call()
+                        )
+                    }
                     return(as_length_one_quo.character(x)) # nolint: return_linter
                 } else {
                     rlang::abort(
@@ -204,6 +210,17 @@ check_span_structure_dots <- function(x) {
                 }
             })
         )
+
+    empty_entries <- names(x_dots)[sapply(x_dots, function(e) length(e) == 0)]
+    if (length(empty_entries) > 0) {
+        rlang::abort(
+            paste0(
+                "The following span_structure() arguments have no column values: ",
+                paste0("`", empty_entries, "`", collapse = ", ")
+            ),
+            call = rlang::caller_call()
+        )
+    }
 
     x_dots[!sapply(x_dots, is.null)]
 }

--- a/R/col_plan.R
+++ b/R/col_plan.R
@@ -218,7 +218,7 @@ check_span_structure_values <- function(
     call = rlang::caller_env()
 ) {
     is_empty_entry <- function(e) {
-      length(e) == 0 || all(vapply(e, is.null, logical(1)))
+        length(e) == 0 || all(vapply(e, is.null, logical(1)))
     }
 
     empty_entries <- names(x)[sapply(x, is_empty_entry)]

--- a/tests/testthat/test-col_plan.R
+++ b/tests/testthat/test-col_plan.R
@@ -1544,6 +1544,13 @@ test_that("col_plan returns correct errors", {
 })
 
 test_that("span_structure misc, including errors", {
+    ## empty inputs
+    expect_error(
+        span_structure(),
+        "span_structure() requires at least one named argument.",
+        fixed = TRUE
+    )
+
     ## unnamed values
     expect_error(
         span_structure(`blah blah blah`),

--- a/tests/testthat/test-col_plan.R
+++ b/tests/testthat/test-col_plan.R
@@ -1579,7 +1579,7 @@ test_that("span_structure misc, including errors", {
     ## empty string column value
     expect_error(
         span_structure(col1 = "", col2 = vars(A, B)),
-        "Empty string values are not allowed in span_structure().",
+        "The following span_structure() arguments have no column values: `col1`",
         fixed = TRUE
     )
 

--- a/tests/testthat/test-col_plan.R
+++ b/tests/testthat/test-col_plan.R
@@ -1575,6 +1575,20 @@ test_that("span_structure misc, including errors", {
         "Invalid entry: `matrix()`\nOnly selection helpers (See <https://tidyselect.r-lib.org/reference>),",
         fixed = TRUE
     )
+
+    ## empty string column value
+    expect_error(
+        span_structure(col1 = "", col2 = vars(A, B)),
+        "Empty string values are not allowed in span_structure().",
+        fixed = TRUE
+    )
+
+    ## empty c() column value
+    expect_error(
+        span_structure(col1 = "Test Label", col2 = c()),
+        "The following span_structure() arguments have no column values: `col2`",
+        fixed = TRUE
+    )
 })
 
 


### PR DESCRIPTION
resolves https://github.com/GSK-Biostatistics/tfrmt/issues/639

`span_structure()` previously gave no message when called with empty inputs. and ran fine but failed when using `tfrmt_to_json`

This PR adds clear, informative error messages for three cases:

- **No arguments**: `span_structure()` → *"span_structure() requires at least one named argument."*
- **Empty string value**: `span_structure(col1 = "")` → *"The following span_structure() arguments have no column values: `col1`"*
- **Empty `c()`**: `span_structure(col1 = "Label", col2 = c())` → *"The following span_structure() arguments have no column values: `col2`"*
